### PR TITLE
fix(resets.js): apply font-weight 700 to h1-h6

### DIFF
--- a/resets/resets.js
+++ b/resets/resets.js
@@ -87,7 +87,7 @@ h4,
 h5,
 h6 {
   font-size: inherit;
-  font-weight: inherit;
+  font-weight: 700;
 }
 
 /*


### PR DESCRIPTION
We used Tailwind's reset with 'inherit' values, but we should use a reset from [fabric](https://github.com/fabric-ds/css/blob/01fd80a27461cf0d593911e974853f84963d0681/src/utils/tailwind/headings.js#L27) that would set headings' font-weight to 700 instead. The issue was reported by a team responsible for the [security page on Finn](https://www.finn.no/min-finn/sikkerhet).
Before:
<img width="541" alt="Screenshot 2023-06-27 at 15 52 58" src="https://github.com/warp-ds/css/assets/41303231/004d5ba2-1d06-4c58-bf89-97f785423859">

After:
<img width="577" alt="Screenshot 2023-06-27 at 15 53 26" src="https://github.com/warp-ds/css/assets/41303231/b9127ffb-2cf4-48ce-8852-94d7e7a0533e">
