### PR TITLE
fix: Replace semantic classes in component-classes with new component tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 settings.json
+.idea/

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -140,7 +140,7 @@ export const switchToggle = {
   trackDisabled: 'i-bg-$color-switch-track-background-disabled',
   handle: 'absolute transform-gpu h-16 w-16 top-4 left-4 rounded-full transition-transform',
   handleSelected: 'translate-x-20',
-  handleNotDisabled: 'i-bg-$color-switch-handle-background shadow-s',
+  handleNotDisabled: 'i-bg-$color-switch-handle-background i-shadow-$shadow-switch-handle',
   handleDisabled: 'i-bg-$color-switch-handle-background-disabled',
   a11y: 'sr-only',
 };
@@ -240,8 +240,8 @@ export const button = {
   buttonPill:
     'font-bold leading-[24] max-w-max focusable justify-center transition-colors ease-in-out rounded-full! min-h-[44px] min-w-[44px] border-0! p-4 i-text-$color-button-pill-icon hover:i-text-$color-button-pill-icon-hover active:i-text-$color-button-pill-icon-active i-bg-$color-button-pill-background hover:i-bg-$color-button-pill-background-hover acive:i-bg-$color-button-pill-background-active inline-flex items-center justify-center hover:bg-clip-padding', // .button--pill   missing:  hover:background-color: rgba(var(--f-blue-600-rgb), 0.1) , and:  hover:border-color: hsla(0, 0%, 100%, 0.4);
   buttonLink:
-    'leading-[24] max-w-max focusable ease-in-out inline s-text-link active:underline hover:underline', //.button--link /* Buttons pretending to be links, (Should rather inherit the actual link setup in the future?)  */
-  // Sizestuff
+    'leading-[24] max-w-max focusable ease-in-out inline i-text-$color-button-link-text active:underline hover:underline', //.button--link /* Buttons pretending to be links, (Should rather inherit the actual link setup in the future?)  */
+  // Size stuff
   buttonSmall: 'px-16 py-6 text-xs leading-xs', // .button--small
   buttonSmallOverride: 'py-8', // .button--small.button--primary, .button--small.button--destructive, .button--small.button--destructive-flat, .button--small.button--order, .button--small.button--quiet
   buttonSmallSecondary: 'py-6', // .button--small.button--secondary
@@ -322,7 +322,7 @@ export const input = {
   disabled: 'i-bg-$color-input-background-disabled i-border-$color-input-border-disabled hover:i-border-$color-input-border-disabled! i-text-$color-input-text-disabled pointer-events-none',
   invalid: 'i-border-$color-input-border-error i-text-$color-input-text-error!',
   readOnly: 'pl-0 bg-transparent border-0 pointer-events-none i-text-$color-input-text-read-only',
-  placeholder: 'placeholder:s-text-placeholder',
+  placeholder: 'placeholder:i-text-$color-input-text-placeholder',
   wrapper: 'relative',
   suffix: 'pr-40',
   prefix: 'pl-40'
@@ -340,15 +340,15 @@ export const select = {
 }
 
 export const label = {
-    label: 'antialiased block relative text-s font-bold pb-4 cursor-pointer i-text-$color-label-text',
-    labelInvalid: 'i-text-$color-label-text-negative',
-    optional: 'pl-8 font-normal text-s i-text-$color-label-optional-text',
+  label: 'antialiased block relative text-s font-bold pb-4 cursor-pointer i-text-$color-label-text',
+  labelInvalid: 'i-text-$color-label-text-negative',
+  optional: 'pl-8 font-normal text-s i-text-$color-label-optional-text',
 }
 
 export const helpText = {
-    helpText: 'text-xs mt-4 block i-text-$color-helptext-text',
-    helpTextValid: 'i-text-$color-helptext-text-positive',
-    helpTextInvalid: 'i-text-$color-helptext-text-negative'
+  helpText: 'text-xs mt-4 block i-text-$color-helptext-text',
+  helpTextValid: 'i-text-$color-helptext-text-positive',
+  helpTextInvalid: 'i-text-$color-helptext-text-negative'
 }
 
 const prefixSuffixWrapperBase =
@@ -387,7 +387,7 @@ export const toggle = {
   label: 'cursor-pointer text-m i-text-$color-label-text py-2 pl-28 select-none relative block before:block before:border before:absolute before:transition-all before:left-0 before:w-20 before:h-20 before:top-2',
   deadToggleLabel: '-mt-2',
   noContent: `before:content-[""]`,
-  indeterminate: `leading-[11] before:s-text-inverted before:text-center before:font-bold before:content-["-"] peer-indeterminate:before:i-border-$color-checkbox-border-active peer-indeterminate:before:i-bg-$color-checkbox-background-active peer-indeterminate:hover:before:i-border-$color-checkbox-border-hover peer-indeterminate:hover:before:i-bg-$color-checkbox-background-active-hover`,
+  indeterminate: `leading-[11] before:i-text-$color-checkbox-icon before:text-center before:font-bold before:content-["-"] peer-indeterminate:before:i-border-$color-checkbox-border-active peer-indeterminate:before:i-bg-$color-checkbox-background-active peer-indeterminate:hover:before:i-border-$color-checkbox-border-hover peer-indeterminate:hover:before:i-bg-$color-checkbox-background-active-hover`,
   labelDisabled: 'pointer-events-none',
   checkbox: 'before:rounded-2 hover:before:i-border-$color-checkbox-border-hover hover:before:i-bg-$color-checkbox-background-hover',
   checkboxChecked: 'peer-checked:before:i-border-$color-checkbox-border-active peer-checked:before:i-bg-$color-checkbox-background-active peer-checked:peer-hover:before:i-border-$color-checkbox-border-active-hover peer-checked:peer-hover:before:i-bg-$color-checkbox-background-active-hover',
@@ -401,7 +401,7 @@ export const toggle = {
   labelRadioBorder: 'i-border-$color-radio-border',
   radioButtons: 'inline-flex relative font-bold rounded-8',
   radioButtonsGroup: 'group',
-  radioButtonsLabel: 'peer-hover:peer-not-checked:i-bg-$color-buttongroup-primary-background-hover peer-checked:i-text-$color-buttongroup-primary-text-active peer-checked:i-bg-$color-buttongroup-primary-background-active peer-checked:i-border-$color-buttongroup-primary-border-active block relative text-s font-bold cursor-pointer i-text-$color-buttongroup-primary-text text-center s-bg-default border-2 i-border-$color-buttongroup-primary-border py-8 pl-12 pr-14 group-first-of-type:rounded-tl-8 group-first-of-type:rounded-bl-8 group-last-of-type:rounded-tr-8 group-last-of-type:rounded-br-8 group-not-last-of-type:border-r-0 peer-checked:z-10 group-not-first:-ml-2',
+  radioButtonsLabel: 'peer-hover:peer-not-checked:i-bg-$color-buttongroup-primary-background-hover peer-checked:i-text-$color-buttongroup-primary-text-active peer-checked:i-bg-$color-buttongroup-primary-background-active peer-checked:i-border-$color-buttongroup-primary-border-active block relative text-s font-bold cursor-pointer i-text-$color-buttongroup-primary-text text-center i-bg-$color-buttongroup-primary-background border-2 i-border-$color-buttongroup-primary-border py-8 pl-12 pr-14 group-first-of-type:rounded-tl-8 group-first-of-type:rounded-bl-8 group-last-of-type:rounded-tr-8 group-last-of-type:rounded-br-8 group-not-last-of-type:border-r-0 peer-checked:z-10 group-not-first:-ml-2',
   radioButtonsJustified: 'flex!',
   radioButtonsGroupJustified: 'grow-1 shrink-0 basis-auto',
   radioButtonsLabelSmall: 'text-xs py-[5px]! px-[8px]!',
@@ -412,15 +412,15 @@ export const toggle = {
 export const clickable = {
   clickable: 'absolute inset-0 h-full w-full appearance-none cursor-pointer focusable focusable-inset',
   clickableNotToggle: 'inset-0 absolute',
-  label: `px-12 ${label.label} py-8! cursor-pointer focusable focusable-inset`, 
+  label: `px-12 ${label.label} py-8! cursor-pointer focusable focusable-inset`,
 }
 
 export const combobox = {
   wrapper: 'relative',
-  combobox: 'absolute left-0 right-0 pb-8 rounded-8 s-bg-default shadow-m',
+  combobox: 'absolute left-0 right-0 pb-8 rounded-8 i-bg-$color-combobox-background i-shadow-$shadow-combobox',
   textMatch: 'font-bold',
   listbox: 'm-0 p-0 select-none list-none',
-  option: 'block cursor-pointer p-8 hover:s-bg-hover',
-  optionSelected: 's-bg-selected',
+  option: 'block cursor-pointer p-8 hover:i-bg-$color-combobox-option-background-hover',
+  optionSelected: 'i-bg-$color-combobox-option-background-selected hover:i-bg-$color-combobox-option-background-selected-hover',
   a11y: 'sr-only',
 }

--- a/tokens/blocket.se/buttons.yml
+++ b/tokens/blocket.se/buttons.yml
@@ -34,6 +34,15 @@ color:
       icon: blue-600
     negative:
       text: white
+      background:
+        _: red-600
+        hover: red-700
+        active: red-800
+      border:
+        _: red-600
+        hover: red-700
+        active: red-800
+      icon: white
       quiet:
         text: red-600
         background:
@@ -45,22 +54,15 @@ color:
           hover: transparent
           active: transparent
         icon: red-600
-      background:
-        _: red-600
-        hover: red-700
-        active: red-800
-      border:
-        _: red-600
-        hover: red-700
-        active: red-800
-      icon: white
     disabled:
-      text: white-100
+      text: white
+      background: bluegray-300
       quiet:
         text: bluegray-300
         border: bluegray-300
-      background: bluegray-300
-    favorite:
+    link:
+      text: s-color-text-link
+    pill:
       background:
         _: transparent
         hover: blue-300-transparentized-30-percent
@@ -78,7 +80,7 @@ color:
       background: gray-100
       icon: gray-500
     utility:
-      text: gray-800
+      text: gray-700
       background:
         _: white
         hover: gray-100
@@ -87,3 +89,13 @@ color:
         _: bluegray-300
         hover: gray-500
         active: gray-700
+      quiet:
+        text: gray-700
+        background:
+          _: transparent
+          hover: bluegray-100
+          active: bluegray-200
+        border:
+          _: transparent
+          hover: transparent
+          active: transparent

--- a/tokens/blocket.se/combobox.yml
+++ b/tokens/blocket.se/combobox.yml
@@ -1,0 +1,14 @@
+---
+token: maps
+
+color:
+  combobox:
+    background: s-color-background-default
+    option:
+      background:
+        hover: s-color-background-hover
+        selected:
+          _: s-color-background-active
+          hover: s-color-background-active-hover
+shadow:
+  combobox: shadow-m

--- a/tokens/blocket.se/input.yml
+++ b/tokens/blocket.se/input.yml
@@ -4,6 +4,7 @@ token: maps
 color:
   input:
     text:
+      placeholder: s-color-text-placeholder
       hint: bluegray-300
       active: gray-700
       filled: gray-700

--- a/tokens/blocket.se/switch.yml
+++ b/tokens/blocket.se/switch.yml
@@ -15,3 +15,6 @@ color:
       background:
         _: white
         disabled: bluegray-300
+shadow:
+  switch:
+    handle: shadow-s

--- a/tokens/finn.no/buttons.yml
+++ b/tokens/finn.no/buttons.yml
@@ -60,6 +60,8 @@ color:
       quiet:
         text: bluegray-300
         border: bluegray-300
+    link:
+      text: s-color-text-link
     pill:
       background:
         _: transparent

--- a/tokens/finn.no/combobox.yml
+++ b/tokens/finn.no/combobox.yml
@@ -1,0 +1,14 @@
+---
+token: maps
+
+color:
+  combobox:
+    background: s-color-background-default
+    option:
+      background:
+        hover: s-color-background-hover
+        selected:
+          _: s-color-background-active
+          hover: s-color-background-active-hover
+shadow:
+  combobox: shadow-m

--- a/tokens/finn.no/input.yml
+++ b/tokens/finn.no/input.yml
@@ -4,6 +4,7 @@ token: maps
 color:
   input:
     text:
+      placeholder: s-color-text-placeholder
       hint: bluegray-300
       active: gray-700
       filled: gray-700

--- a/tokens/finn.no/switch.yml
+++ b/tokens/finn.no/switch.yml
@@ -15,3 +15,6 @@ color:
       background:
         _: white
         disabled: bluegray-300
+shadow:
+  switch:
+    handle: shadow-s

--- a/tokens/tori.fi/buttons.yml
+++ b/tokens/tori.fi/buttons.yml
@@ -60,6 +60,8 @@ color:
       quiet:
         text: gray-300
         border: gray-300
+    link:
+      text: s-color-text-link
     pill:
       background:
         _: transparent

--- a/tokens/tori.fi/combobox.yml
+++ b/tokens/tori.fi/combobox.yml
@@ -1,0 +1,14 @@
+---
+token: maps
+
+color:
+  combobox:
+    background: s-color-background-default
+    option:
+      background:
+        hover: s-color-background-hover
+        selected:
+          _: s-color-background-active
+          hover: s-color-background-active-hover
+shadow:
+  combobox: shadow-m

--- a/tokens/tori.fi/input.yml
+++ b/tokens/tori.fi/input.yml
@@ -4,6 +4,7 @@ token: maps
 color:
   input:
     text:
+      placeholder: s-color-text-placeholder
       hint: gray-300
       active: gray-700
       filled: gray-700

--- a/tokens/tori.fi/switch.yml
+++ b/tokens/tori.fi/switch.yml
@@ -15,3 +15,6 @@ color:
       background:
         _: white
         disabled: gray-300
+shadow:
+  switch:
+    handle: shadow-s


### PR DESCRIPTION
Add new component tokens to replace direct usage of semantic classes in component-classes.

This PR will replace these:
https://github.com/warp-ds/tokens/pull/83
https://github.com/warp-ds/component-classes/pull/100
