### PR TITLE
fix: update types, add new for shortcuts and classes

### DIFF
--- a/component-classes/classes.d.ts
+++ b/component-classes/classes.d.ts
@@ -1,0 +1,1 @@
+export const classes: FlatArray<string[] | string[][], 0 | 2 | 1 | -1 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20>[];

--- a/component-classes/shortcuts.d.ts
+++ b/component-classes/shortcuts.d.ts
@@ -1,0 +1,15 @@
+export const buttons: {
+    button: string;
+    'button--secondary': string;
+    'button--default': string;
+    'button--small': string;
+    'button--link': string;
+    'button--primary': string;
+    'button--cta': string;
+    'button--pill': string;
+    'button--utility': string;
+    'button--utility-flat': string;
+    'button--destructive': string;
+    'button--destructive-flat': string;
+    'button--flat': string;
+};

--- a/component-classes/tsconfig.json
+++ b/component-classes/tsconfig.json
@@ -10,7 +10,9 @@
         "removeComments": false
     },
     "files": [
-        "./index.js"
+        "./index.js",
+        "./shortcuts.js",
+        "./classes.js"
     ],
     "exclude": [
         "node_modules",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "pnpm build:tokens && pnpm build:resets && pnpm build:cc",
     "commit": "cz",
     "semantic-release": "semantic-release",
-    "build:cc": "cd component-classes && tsc && vite build",
+    "build:cc": "cd component-classes && rm -rf *.d.ts && tsc && vite build",
     "build:tokens": "cd tokens && node index.js",
     "build:resets": "cd resets && node index.js"
   },
@@ -17,7 +17,19 @@
     "./component-classes/classes": "./component-classes/classes.js",
     "./component-classes/shortcuts": "./component-classes/shortcuts.js"
   },
-  "types": "./component-classes/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "./component-classes": [
+        "./component-classes/index.d.ts"
+      ],
+      "./component-classes/classes": [
+        "./component-classes/classes.d.ts"
+      ],
+      "./component-classes/shortcuts": [
+        "./component-classes/shortcuts.d.ts"
+      ]
+    }
+  },
   "files": [
     "./component-classes/index.js",
     "./component-classes/classes.js",


### PR DESCRIPTION
While updating our component framework packages I've noticed that we are not adding all the types needed. Both `classes` and `shortcuts` should also be exported with corresponding type declarations. I've struggled here a bit as I got a lot of errors. Specifically one that is described very good [here](https://www.codejam.info/2021/10/typescript-cannot-write-file-overwrite-input.html) 

Before|After
---|---
<img width="1150" alt="image" src="https://github.com/warp-ds/css/assets/37986637/7ec4552e-3848-4eb3-a9d6-255098b1ebf5">|<img width="1031" alt="image" src="https://github.com/warp-ds/css/assets/37986637/65b27cce-9f67-4969-8890-2a60808af376">

