### PR TITLE
fix: Remove old token for focus outlines

### DIFF
--- a/tokens/blocket.se/focus.yml
+++ b/tokens/blocket.se/focus.yml
@@ -1,5 +1,0 @@
----
-token: maps
-
-color:
-  focused: aqua-400

--- a/tokens/finn.no/focus.yml
+++ b/tokens/finn.no/focus.yml
@@ -1,5 +1,0 @@
----
-token: maps
-
-color:
-  focused: aqua-400

--- a/tokens/tori.fi/focus.yml
+++ b/tokens/tori.fi/focus.yml
@@ -1,5 +1,0 @@
----
-token: maps
-
-color:
-  focused: aqua-400


### PR DESCRIPTION
To be merged after: https://github.com/warp-ds/drive/pull/139