### PR TITLE
fix(tokens): process @import rule to inline font definitions in brand CSS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
     "./component-classes/index.d.ts"
   ],
   "dependencies": {
-    "drnm": "^0.9.0",
-    "lightningcss": "^1.19.0",
-    "@sindresorhus/slugify": "^2.2.0",
+    "@warp-ds/fonts": "1.1.0-next.2",
     "@warp-ds/tokenizer": "^0.0.2",
     "@warp-ds/uno": "^1.0.0-alpha.49"
   },
@@ -45,7 +43,12 @@
     "typescript": "^4.9.5",
     "unocss": "^0.53.1",
     "vite": "^4.3.9",
-    "vite-plugin-dts": "^2.3.0"
+    "vite-plugin-dts": "^2.3.0",
+    "@sindresorhus/slugify": "^2.2.0",
+    "drnm": "^0.9.0",
+    "lightningcss": "^1.19.0",
+    "postcss": "^8.4.24",
+    "postcss-import": "^15.1.0"
   },
   "eslintConfig": {
     "extends": "@warp-ds"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "./component-classes/index.d.ts"
   ],
   "dependencies": {
-    "@warp-ds/fonts": "1.1.0-next.2",
+    "@warp-ds/fonts": "1.1.0",
     "@warp-ds/tokenizer": "^0.0.2",
     "@warp-ds/uno": "^1.0.0-alpha.49"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@warp-ds/fonts':
-    specifier: 1.1.0-next.2
-    version: 1.1.0-next.2
+    specifier: 1.1.0
+    version: 1.1.0
   '@warp-ds/tokenizer':
     specifier: ^0.0.2
     version: 0.0.2
@@ -1246,8 +1246,8 @@ packages:
       eslint: 8.43.0
     dev: true
 
-  /@warp-ds/fonts@1.1.0-next.2:
-    resolution: {integrity: sha512-xIdS0lE2CqRgbd4NMjTQ183Xd3+UmJGApdnJxlRavDXesKn+OQTdC3VU57Ao3aCbRfe/gluLJB1YERLAtg0I1A==}
+  /@warp-ds/fonts@1.1.0:
+    resolution: {integrity: sha512-kLNZzK3o0rMJApm7/YT3K7rYoFKgH5PyJMTVwv34O4Dx6ikfN7appc4f2DFYkE2XY6gifpD5F2r1ftcJtdW4+w==}
     dev: false
 
   /@warp-ds/tokenizer@0.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,25 +1,19 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@sindresorhus/slugify':
-    specifier: ^2.2.0
-    version: 2.2.0
+  '@warp-ds/fonts':
+    specifier: 1.1.0-next.2
+    version: 1.1.0-next.2
   '@warp-ds/tokenizer':
     specifier: ^0.0.2
     version: 0.0.2
   '@warp-ds/uno':
     specifier: ^1.0.0-alpha.49
     version: 1.0.0-alpha.49
-  drnm:
-    specifier: ^0.9.0
-    version: 0.9.0
-  lightningcss:
-    specifier: ^1.19.0
-    version: 1.19.0
 
 devDependencies:
   '@eik/cli':
@@ -34,15 +28,30 @@ devDependencies:
   '@semantic-release/git':
     specifier: ^10.0.1
     version: 10.0.1(semantic-release@20.1.3)
+  '@sindresorhus/slugify':
+    specifier: ^2.2.0
+    version: 2.2.0
   '@warp-ds/eslint-config':
     specifier: ^0.0.1
     version: 0.0.1(eslint@8.43.0)
   cz-conventional-changelog:
     specifier: ^3.3.0
     version: 3.3.0
+  drnm:
+    specifier: ^0.9.0
+    version: 0.9.0
   eslint:
     specifier: ^8.43.0
     version: 8.43.0
+  lightningcss:
+    specifier: ^1.19.0
+    version: 1.19.0
+  postcss:
+    specifier: ^8.4.24
+    version: 8.4.24
+  postcss-import:
+    specifier: ^15.1.0
+    version: 15.1.0(postcss@8.4.24)
   semantic-release:
     specifier: ^20.1.3
     version: 20.1.3
@@ -963,14 +972,14 @@ packages:
     dependencies:
       '@sindresorhus/transliterate': 1.6.0
       escape-string-regexp: 5.0.0
-    dev: false
+    dev: true
 
   /@sindresorhus/transliterate@1.6.0:
     resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
     engines: {node: '>=12'}
     dependencies:
       escape-string-regexp: 5.0.0
-    dev: false
+    dev: true
 
   /@tootallnate/once@2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
@@ -1236,6 +1245,10 @@ packages:
     dependencies:
       eslint: 8.43.0
     dev: true
+
+  /@warp-ds/fonts@1.1.0-next.2:
+    resolution: {integrity: sha512-xIdS0lE2CqRgbd4NMjTQ183Xd3+UmJGApdnJxlRavDXesKn+OQTdC3VU57Ao3aCbRfe/gluLJB1YERLAtg0I1A==}
+    dev: false
 
   /@warp-ds/tokenizer@0.0.2:
     resolution: {integrity: sha512-pEtBvP6my14f1kOmYSoDNhofGK/L2yNqnZkEotvY6boVs3jcIncHpgo9Nt4AHOiAvzDrPP0t8b36jwqGaWzNPg==}
@@ -2041,7 +2054,7 @@ packages:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
     hasBin: true
-    dev: false
+    dev: true
 
   /diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -2072,7 +2085,7 @@ packages:
 
   /drnm@0.9.0:
     resolution: {integrity: sha512-ZNkurkg7xoWPQNTf4TfUxS/lvm+zPve01xjLS/RUWCPr6OB3zBlM4Y2dIXkR6NsELojppfum8+wdWZ0vnjdwmg==}
-    dev: false
+    dev: true
 
   /duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
@@ -2150,6 +2163,7 @@ packages:
   /escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
+    dev: true
 
   /eslint-scope@7.2.0:
     resolution: {integrity: sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==}
@@ -3287,7 +3301,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-darwin-x64@1.19.0:
@@ -3296,7 +3310,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-linux-arm-gnueabihf@1.19.0:
@@ -3305,7 +3319,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-linux-arm64-gnu@1.19.0:
@@ -3314,7 +3328,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-linux-arm64-musl@1.19.0:
@@ -3323,7 +3337,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-linux-x64-gnu@1.19.0:
@@ -3332,7 +3346,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-linux-x64-musl@1.19.0:
@@ -3341,7 +3355,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-win32-x64-msvc@1.19.0:
@@ -3350,7 +3364,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss@1.19.0:
@@ -3367,7 +3381,7 @@ packages:
       lightningcss-linux-x64-gnu: 1.19.0
       lightningcss-linux-x64-musl: 1.19.0
       lightningcss-win32-x64-msvc: 1.19.0
-    dev: false
+    dev: true
 
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -4221,6 +4235,11 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
+  /pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
@@ -4239,6 +4258,22 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       find-up: 6.3.0
+    dev: true
+
+  /postcss-import@15.1.0(postcss@8.4.24):
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss: 8.4.24
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.2
+    dev: true
+
+  /postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: true
 
   /postcss@8.4.24:
@@ -4290,6 +4325,12 @@ packages:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+    dev: true
+
+  /read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+    dependencies:
+      pify: 2.3.0
     dev: true
 
   /read-pkg-up@7.0.1:

--- a/tokens/index.js
+++ b/tokens/index.js
@@ -4,17 +4,27 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { minify } from '../css-minify.js';
 import drnm from 'drnm';
+import postcss from 'postcss';
+import atImport from 'postcss-import';
 
 const __dirname = drnm(import.meta.url);
 const outPath = path.join(__dirname, '../dist/tokens');
 fs.mkdirSync(outPath, { recursive: true });
 
-function process(tld) {
+async function process(tld) {
+  const slugifiedName = slugify(tld);
+  const filename = path.join(outPath, slugifiedName) + '.css';
+
+  const fontDefinitions = `@import '@warp-ds/fonts/dist/${path.basename(filename)}';`;
   const tokens = tokenize(`./${tld}`);
-  const css = minify(tokens);
-  const filename = path.join(outPath, slugify(tld)) + '.css';
-  const fontsImport = `@import'https://assets.finn.no/pkg/@warp-ds/fonts/v1/${path.basename(filename)}';`;
-  fs.writeFileSync(filename, `${fontsImport}${css}`, 'utf-8');
+  const css = `${fontDefinitions};${tokens}`;
+
+  const plugins = [
+    atImport,
+  ];
+  const result = await postcss(plugins).process(css, { from: undefined, to: filename });
+
+  fs.writeFileSync(filename, minify(result.css), { encoding: 'utf-8' });
 }
 
 process('finn.no');


### PR DESCRIPTION
We shouldn't use @import rule with urls due to performance issues. More info in this article: https://www.debugbear.com/blog/avoid-css-import#:~:text=Why%20does%20CSS%20%40import%20slow,can%20download%20them%20in%20parallel

Fixes [WARP-12: Use inline font-face declarations in brand CSS files](https://nmp-jira.atlassian.net/browse/WARP-12)