### PR TITLE
fix(component-classes): export focusable class of clickable component

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -414,6 +414,7 @@ export const clickable = {
   clickable: 'absolute inset-0 h-full w-full appearance-none cursor-pointer focusable focusable-inset',
   clickableNotToggle: 'inset-0 absolute',
   label: `px-12 ${label.label} py-8! cursor-pointer focusable focusable-inset`,
+  focusable: 'focusable',
 };
 
 export const combobox = {


### PR DESCRIPTION
Fixes outline of button and anchor variants of Clickable.
[Warp-178](https://nmp-jira.atlassian.net/browse/WARP-178?atlOrigin=eyJpIjoiYjFhMTg0MmJkZmU4NDJhZmEzMDg0Y2E5ZWJjYTk3NGIiLCJwIjoiaiJ9)

Before:
<img width="680" alt="Screenshot 2023-07-04 at 15 53 30" src="https://github.com/warp-ds/css/assets/41303231/3f1ab51c-7f5c-4c00-9151-b4b3b30afb23">
<img width="675" alt="Screenshot 2023-07-04 at 15 53 35" src="https://github.com/warp-ds/css/assets/41303231/890fbe15-ccb1-446c-95e3-539a7c80365d">

After:
<img width="676" alt="Screenshot 2023-07-04 at 15 41 13" src="https://github.com/warp-ds/css/assets/41303231/c45044f0-823b-46a2-b102-1185d9b2eb48">
<img width="670" alt="Screenshot 2023-07-04 at 15 41 07" src="https://github.com/warp-ds/css/assets/41303231/ab9eb3bb-2b60-4f87-914e-84f6dc5da4c2">

