### PR TITLE
fix(tokens): restore deprecated foundation/background/outline color tokens

### DIFF
--- a/tokens/blocket.se/colors.yml
+++ b/tokens/blocket.se/colors.yml
@@ -4,6 +4,7 @@ token: defs
 white: white
 black: black
 transparent: transparent
+inherit: inherit
 blue:
   50: "#eff5ff"
   100: "#e1edfe"

--- a/tokens/blocket.se/deprecated.yml
+++ b/tokens/blocket.se/deprecated.yml
@@ -21,3 +21,51 @@ color:
       _: blue-600
       hover: blue-800
       visited: inherit
+
+s:
+  color:
+    background:
+      default: white
+      subtle:
+        default: bluegray-50
+      primary:
+        default: blue-600
+      positive:
+        default: green-50
+      negative:
+        default: red-50
+      warning:
+        default: yellow-50
+      info:
+        default: aqua-50
+
+    border:
+      default: bluegray-300
+      primary:
+        default: blue-600
+        subtle:
+          default: blue-300
+      positive:
+        default: green-600
+        subtle:
+          default: green-300
+      negative:
+        default: red-600
+        subtle:
+          default: red-300
+      warning:
+        default: yellow-600
+        subtle:
+          default: yellow-300
+      info:
+        default: aqua-600
+        subtle:
+          default: aqua-300
+
+    icon:
+      default: gray-500
+      subtle:
+        default: bluegray-500
+
+    text:
+      default: gray-700

--- a/tokens/blocket.se/deprecated.yml
+++ b/tokens/blocket.se/deprecated.yml
@@ -1,0 +1,23 @@
+---
+token: maps
+
+color:
+  focused: aqua-400
+  background:
+    _: white
+    subtle: bluegray-50
+    interactive:
+      _: white
+      hover: bluegray-100
+      selected: bluegray-100
+  text:
+    _: gray-700
+    subtle: gray-500
+    placeholder: bluegray-300
+    inverted:
+      _: white
+      subtle: gray-50
+    link:
+      _: blue-600
+      hover: blue-800
+      visited: inherit

--- a/tokens/finn.no/colors.yml
+++ b/tokens/finn.no/colors.yml
@@ -4,6 +4,7 @@ token: defs
 white: white
 black: black
 transparent: transparent
+inherit: inherit
 blue:
   50: "#eff5ff"
   100: "#e1edfe"

--- a/tokens/finn.no/deprecated.yml
+++ b/tokens/finn.no/deprecated.yml
@@ -21,3 +21,51 @@ color:
       _: blue-600
       hover: blue-800
       visited: inherit
+
+s:
+  color:
+    background:
+      default: white
+      subtle:
+        default: bluegray-50
+      primary:
+        default: blue-600
+      positive:
+        default: green-50
+      negative:
+        default: red-50
+      warning:
+        default: yellow-50
+      info:
+        default: aqua-50
+
+    border:
+      default: bluegray-300
+      primary:
+        default: blue-600
+        subtle:
+          default: blue-300
+      positive:
+        default: green-600
+        subtle:
+          default: green-300
+      negative:
+        default: red-600
+        subtle:
+          default: red-300
+      warning:
+        default: yellow-600
+        subtle:
+          default: yellow-300
+      info:
+        default: aqua-600
+        subtle:
+          default: aqua-300
+
+    icon:
+      default: gray-500
+      subtle:
+        default: bluegray-500
+
+    text:
+      default: gray-700

--- a/tokens/finn.no/deprecated.yml
+++ b/tokens/finn.no/deprecated.yml
@@ -1,0 +1,23 @@
+---
+token: maps
+
+color:
+  focused: aqua-400
+  background:
+    _: white
+    subtle: bluegray-50
+    interactive:
+      _: white
+      hover: bluegray-100
+      selected: bluegray-100
+  text:
+    _: gray-700
+    subtle: gray-500
+    placeholder: bluegray-300
+    inverted:
+      _: white
+      subtle: gray-50
+    link:
+      _: blue-600
+      hover: blue-800
+      visited: inherit

--- a/tokens/tori.fi/colors.yml
+++ b/tokens/tori.fi/colors.yml
@@ -4,6 +4,7 @@ token: defs
 white: white
 black: black
 transparent: transparent
+inherit: inherit
 watermelon:
   50: "#FFF3F2"
   100: "#FFE6E4"

--- a/tokens/tori.fi/deprecated.yml
+++ b/tokens/tori.fi/deprecated.yml
@@ -1,0 +1,23 @@
+---
+token: maps
+
+color:
+  focused: aqua-400
+  background:
+    _: white
+    subtle: gray-50
+    interactive:
+      _: white
+      hover: gray-100
+      selected: gray-100
+  text:
+    _: gray-700
+    subtle: gray-500
+    placeholder: gray-300
+    inverted:
+      _: white
+      subtle: gray-50
+    link:
+      _: watermelon-600
+      hover: watermelon-800
+      visited: inherit

--- a/tokens/tori.fi/deprecated.yml
+++ b/tokens/tori.fi/deprecated.yml
@@ -21,3 +21,51 @@ color:
       _: watermelon-600
       hover: watermelon-800
       visited: inherit
+
+s:
+  color:
+    background:
+      default: white
+      subtle:
+        default: gray-50
+      primary:
+        default: watermelon-600
+      positive:
+        default: green-50
+      negative:
+        default: red-50
+      warning:
+        default: yellow-50
+      info:
+        default: petroleum-50
+
+    border:
+      default: gray-300
+      primary:
+        default: watermelon-600
+        subtle:
+          default: watermelon-300
+      positive:
+        default: green-600
+        subtle:
+          default: green-300
+      negative:
+        default: red-600
+        subtle:
+          default: red-300
+      warning:
+        default: yellow-600
+        subtle:
+          default: yellow-300
+      info:
+        default: petroleum-600
+        subtle:
+          default: petroleum-300
+
+    icon:
+      default: gray-500
+      subtle:
+        default: gray-500
+
+    text:
+      default: gray-900


### PR DESCRIPTION
## Background

Some apps will still use an [old version of resets.css](https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.7/resets.css) in production before we bump the aliased version of @warp-ds/css from current `1.0.0-alpha.7` to `1.0.0-alpha.27` (or `1.0.0` when that is available). That CSS relies on old color tokens (like `--w-color-background`, `--w-color-text`) that were removed in favour of semantic color tokens. In order for layouts to use the new semantic tokens and then let podlet apps safely align with the other dependencies and stylesheets, we need to ensure backward compatibility of the tokens for some time. 

## Reverted commits

- [fix: Remove old token for focus outlines](https://github.com/warp-ds/css/commit/1d54f775fda04952a827f9ca756484ac49614d8f)
- [fix: Cleaned out old token files with duplicated or unused tokens](https://github.com/warp-ds/css/commit/76a9e0126a1621a5f950b9343814af99385c2de7)
- [fix: Remove any ending "-default" suffixes from the semantic tokens](https://github.com/warp-ds/css/pull/12)