### PR TITLE
fix(component-classes): add bg-transparent to clickableNotToggle

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -412,7 +412,7 @@ export const toggle = {
 
 export const clickable = {
   clickable: 'absolute inset-0 h-full w-full appearance-none cursor-pointer focusable focusable-inset',
-  clickableNotToggle: 'inset-0 absolute',
+  clickableNotToggle: 'inset-0 absolute bg-transparent',
   label: `px-12 ${label.label} py-8! cursor-pointer focusable focusable-inset`,
   focusable: 'focusable',
 };


### PR DESCRIPTION
Before:
![Screenshot 2023-07-06 at 09 09 21](https://github.com/warp-ds/css/assets/41303231/35c8f6cf-23d0-4913-963a-2bf0213953ff)

After:
![Screenshot 2023-07-06 at 09 09 13](https://github.com/warp-ds/css/assets/41303231/2c28553e-5f8d-49bb-8bdd-517214742bca)
