### PR TITLE
fix: transparent background in Clickable, Tabs, Buttons

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -387,10 +387,11 @@ export namespace toggle {
     export { a11y_5 as a11y };
 }
 export namespace clickable {
-    export const clickable: string;
-    export const clickableNotToggle: string;
+    export const toggle: string;
     const label_6: string;
     export { label_6 as label };
+    export const buttonOrLink: string;
+    export const buttonOrLinkStretch: string;
 }
 export namespace combobox {
     const wrapper_11: string;

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -178,7 +178,7 @@ export const tabs = {
 };
 
 export const tab = {
-  tab: 'grid items-center font-bold gap-8 focusable antialias p-16 pb-8 border-b-4 i-text-$color-tabs-text i-border-$color-tabs-border hover:i-text-$color-tabs-text-hover hover:i-border-$color-tabs-border-hover',
+  tab: 'grid items-center font-bold gap-8 focusable antialias p-16 pb-8 border-b-4 bg-transparent i-text-$color-tabs-text i-border-$color-tabs-border hover:i-text-$color-tabs-text-hover hover:i-border-$color-tabs-border-hover',
   tabActive: 'i-text-$color-tabs-text-active',
   icon: 'mx-auto hover:i-text-$color-tabs-text-hover',
   iconUnderlinedActive: 'i-text-$color-tabs-text-active',

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -411,10 +411,10 @@ export const toggle = {
 };
 
 export const clickable = {
-  clickable: 'absolute inset-0 h-full w-full appearance-none cursor-pointer focusable focusable-inset',
-  clickableNotToggle: 'inset-0 absolute bg-transparent',
+  toggle: 'absolute inset-0 h-full w-full appearance-none cursor-pointer focusable focusable-inset',
   label: `px-12 ${label.label} py-8! cursor-pointer focusable focusable-inset`,
-  focusable: 'focusable',
+  buttonOrLink: 'bg-transparent focusable',
+  buttonOrLinkStretch: 'inset-0 absolute',
 };
 
 export const combobox = {

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -240,7 +240,7 @@ export const button = {
   buttonPill:
     'font-bold text-m leading-[24] max-w-max focusable justify-center transition-colors ease-in-out rounded-full! min-h-[44px] min-w-[44px] border-0! p-4 i-text-$color-button-pill-icon hover:i-text-$color-button-pill-icon-hover active:i-text-$color-button-pill-icon-active i-bg-$color-button-pill-background hover:i-bg-$color-button-pill-background-hover acive:i-bg-$color-button-pill-background-active inline-flex items-center justify-center hover:bg-clip-padding', // .button--pill   missing:  hover:background-color: rgba(var(--f-blue-600-rgb), 0.1) , and:  hover:border-color: hsla(0, 0%, 100%, 0.4);
   buttonLink:
-    'bg-transparent leading-[24] max-w-max bg-transparent focusable ease-in-out inline i-text-$color-button-link-text active:underline hover:underline', //.button--link /* Buttons pretending to be links, (Should rather inherit the actual link setup in the future?)  */
+    'leading-[24] max-w-max bg-transparent focusable ease-in-out inline i-text-$color-button-link-text active:underline hover:underline', //.button--link /* Buttons pretending to be links, (Should rather inherit the actual link setup in the future?)  */
   // Size stuff
   buttonSmall: 'px-16 py-6 text-xs', // .button--small
   buttonSmallOverride: 'py-8', // .button--small.button--primary, .button--small.button--destructive, .button--small.button--destructive-flat, .button--small.button--order, .button--small.button--quiet

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -240,7 +240,7 @@ export const button = {
   buttonPill:
     'font-bold text-m leading-[24] max-w-max focusable justify-center transition-colors ease-in-out rounded-full! min-h-[44px] min-w-[44px] border-0! p-4 i-text-$color-button-pill-icon hover:i-text-$color-button-pill-icon-hover active:i-text-$color-button-pill-icon-active i-bg-$color-button-pill-background hover:i-bg-$color-button-pill-background-hover acive:i-bg-$color-button-pill-background-active inline-flex items-center justify-center hover:bg-clip-padding', // .button--pill   missing:  hover:background-color: rgba(var(--f-blue-600-rgb), 0.1) , and:  hover:border-color: hsla(0, 0%, 100%, 0.4);
   buttonLink:
-    'leading-[24] max-w-max bg-transparent focusable ease-in-out inline i-text-$color-button-link-text active:underline hover:underline', //.button--link /* Buttons pretending to be links, (Should rather inherit the actual link setup in the future?)  */
+    'bg-transparent leading-[24] max-w-max bg-transparent focusable ease-in-out inline i-text-$color-button-link-text active:underline hover:underline', //.button--link /* Buttons pretending to be links, (Should rather inherit the actual link setup in the future?)  */
   // Size stuff
   buttonSmall: 'px-16 py-6 text-xs', // .button--small
   buttonSmallOverride: 'py-8', // .button--small.button--primary, .button--small.button--destructive, .button--small.button--destructive-flat, .button--small.button--order, .button--small.button--quiet


### PR DESCRIPTION
## Changes
- move bg-transparent to clickable.button and add focusable class
- fix similar issue with background color in Tabs and Buttons
- rename clickable classes to align the Clickable component in React & Vue
 
### Before:
**Button group**
<img width="72" alt="Screenshot 2023-07-07 at 10 43 06" src="https://github.com/warp-ds/component-classes/assets/41303231/e88d932b-ca40-4ead-8983-eba37cd0b3ab">
<img width="158" alt="Screenshot 2023-07-07 at 10 43 11" src="https://github.com/warp-ds/component-classes/assets/41303231/56699f2d-9546-43f9-8c7f-a23458d00dd3">
**Clickable Box**
<img width="253" alt="Screenshot 2023-07-07 at 10 43 20" src="https://github.com/warp-ds/component-classes/assets/41303231/6b8860ae-701c-4574-a3cc-d231ca214838">
**Tabs**
<img width="682" alt="Screenshot 2023-07-07 at 11 01 50" src="https://github.com/warp-ds/component-classes/assets/41303231/a456553f-a3f3-489e-99bf-484720d3d229">



### After:
<img width="172" alt="Screenshot 2023-07-07 at 10 36 58" src="https://github.com/warp-ds/component-classes/assets/41303231/39cfb486-415c-4064-9189-142ac64706a9">
<img width="256" alt="Screenshot 2023-07-07 at 10 43 28" src="https://github.com/warp-ds/component-classes/assets/41303231/4be0418c-8e39-44b8-a5f0-b80c64b5b985">
<img width="677" alt="Screenshot 2023-07-07 at 11 04 47" src="https://github.com/warp-ds/component-classes/assets/41303231/a8a5f675-0cbc-4fdd-98d9-fffcd2e5422a">


