### PR TITLE
fix(cc-button): make text-xs override leading-[24] on small buttons

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -242,7 +242,7 @@ export const button = {
   buttonLink:
     'leading-[24] max-w-max bg-transparent focusable ease-in-out inline i-text-$color-button-link-text active:underline hover:underline', //.button--link /* Buttons pretending to be links, (Should rather inherit the actual link setup in the future?)  */
   // Size stuff
-  buttonSmall: 'px-16 py-6 text-xs', // .button--small
+  buttonSmall: 'px-16 py-6 text-xs!', // .button--small
   buttonSmallOverride: 'py-8', // .button--small.button--primary, .button--small.button--destructive, .button--small.button--destructive-flat, .button--small.button--order, .button--small.button--quiet
   buttonSmallSecondary: 'py-6', // .button--small.button--secondary
   buttonSmallUtility: 'py-7 px-15', // .button--small.button--secondary


### PR DESCRIPTION
## Background
After adding support to arbitrary `leading` classes in `@warp-ds/uno@alpha.49`, `leading-[24]` on buttons started working, overriding some line-height values. Therefore `text-xs` class on `buttonSmall` now has an important rule which prevents `leading-[24]` from setting a wrong line-height on small buttons.

Before:
<img width="375" alt="Screenshot 2023-07-10 at 11 00 39" src="https://github.com/warp-ds/component-classes/assets/41303231/3072ed0e-9c31-481b-acc9-a156d660d813">

After:
<img width="373" alt="Screenshot 2023-07-10 at 11 01 26" src="https://github.com/warp-ds/component-classes/assets/41303231/873f757a-41f6-4186-b975-9100ff8c5aa1">
