### PR TITLE
fix(tokens): remove inlined fonts from brand CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,9 +58,7 @@
     "vite-plugin-dts": "^2.3.0",
     "@sindresorhus/slugify": "^2.2.0",
     "drnm": "^0.9.0",
-    "lightningcss": "^1.19.0",
-    "postcss": "^8.4.24",
-    "postcss-import": "^15.1.0"
+    "lightningcss": "^1.19.0"
   },
   "eslintConfig": {
     "extends": "@warp-ds"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,12 +46,6 @@ devDependencies:
   lightningcss:
     specifier: ^1.19.0
     version: 1.19.0
-  postcss:
-    specifier: ^8.4.24
-    version: 8.4.24
-  postcss-import:
-    specifier: ^15.1.0
-    version: 15.1.0(postcss@8.4.24)
   semantic-release:
     specifier: ^20.1.3
     version: 20.1.3
@@ -4235,11 +4229,6 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
   /pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
@@ -4258,22 +4247,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       find-up: 6.3.0
-    dev: true
-
-  /postcss-import@15.1.0(postcss@8.4.24):
-    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-    dependencies:
-      postcss: 8.4.24
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.2
-    dev: true
-
-  /postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: true
 
   /postcss@8.4.24:
@@ -4325,12 +4298,6 @@ packages:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-    dev: true
-
-  /read-cache@1.0.0:
-    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
-    dependencies:
-      pify: 2.3.0
     dev: true
 
   /read-pkg-up@7.0.1:

--- a/tokens/index.js
+++ b/tokens/index.js
@@ -4,27 +4,16 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { minify } from '../css-minify.js';
 import drnm from 'drnm';
-import postcss from 'postcss';
-import atImport from 'postcss-import';
 
 const __dirname = drnm(import.meta.url);
 const outPath = path.join(__dirname, '../dist/tokens');
 fs.mkdirSync(outPath, { recursive: true });
 
 async function process(tld) {
-  const slugifiedName = slugify(tld);
-  const filename = path.join(outPath, slugifiedName) + '.css';
-
-  const fontDefinitions = `@import '@warp-ds/fonts/dist/${path.basename(filename)}';`;
   const tokens = tokenize(`./${tld}`);
-  const css = `${fontDefinitions};${tokens}`;
-
-  const plugins = [
-    atImport,
-  ];
-  const result = await postcss(plugins).process(css, { from: undefined, to: filename });
-
-  fs.writeFileSync(filename, minify(result.css), { encoding: 'utf-8' });
+  const css = minify(tokens);
+  const filename = path.join(outPath, slugify(tld)) + '.css';
+  fs.writeFileSync(filename, css, 'utf-8');
 }
 
 process('finn.no');


### PR DESCRIPTION
Fixes [WARP-202](https://nmp-jira.atlassian.net/browse/WARP-202?atlOrigin=eyJpIjoiMGIzYzIzNWFkMWM3NDlhZmExYWE5ZjQ3OGU1ODNhOWIiLCJwIjoiaiJ9)

Although fonts follow brands, we want to load font definitions separately from the brand CSS. The reason is that fonts are highly unlikely to change compared to the brand file and loading them as a separate CSS file from `https://assets.finn.no/pkg/@warp-ds/fonts/v1` allows browsers to keep this file cached, which ensures fonts are available as fast as possible on a page.