### PR TITLE
fix(resets): publish only minified versions of css

### DIFF
--- a/resets/index.js
+++ b/resets/index.js
@@ -10,10 +10,10 @@ fs.mkdirSync(outPath, { recursive: true });
 
 function process(tld) {
   const css = minify(resets);
-  const nonMinified = path.join(outPath, tld) + '.css';
-  const minified = path.join(outPath, tld) + '.min.css';
+  const minified = path.join(outPath, tld) + '.css';
+  const deprecatedMinified = path.join(outPath, tld) + '.min.css'; // Remove when no apps use resets.min.css
   fs.writeFileSync(minified, css, 'utf-8');
-  fs.writeFileSync(nonMinified, resets, 'utf-8');
+  fs.writeFileSync(deprecatedMinified, css, 'utf-8');
 }
 
 process('resets');

--- a/resets/index.js
+++ b/resets/index.js
@@ -10,10 +10,10 @@ fs.mkdirSync(outPath, { recursive: true });
 
 function process(tld) {
   const css = minify(resets);
-  const minified = path.join(outPath, tld) + '.css';
-  const deprecatedMinified = path.join(outPath, tld) + '.min.css'; // Remove when no apps use resets.min.css
-  fs.writeFileSync(minified, css, 'utf-8');
-  fs.writeFileSync(deprecatedMinified, css, 'utf-8');
+  const filename = path.join(outPath, tld) + '.css';
+  const deprecatedFilename = path.join(outPath, tld) + '.min.css'; // Remove when no apps use resets.min.css
+  fs.writeFileSync(filename, css, 'utf-8');
+  fs.writeFileSync(deprecatedFilename, css, 'utf-8');
 }
 
 process('resets');


### PR DESCRIPTION
We should be consistent and always publish minified css files, without `min` in the file name. As there might still be some apps that are requesting `resets.min.css`, we must keep the deprecated file. Once we know this file is no longer requested, we should remove it from the build.