### PR TITLE
chore: use 'next' instead of 'alpha'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,9 @@ name: Release
 on:
   push:
     branches:
-    - main
-    - alpha
-    - next
-    - beta
+      - main
+      - next
+      - beta
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Rebase alpha to main
+      - name: Rebase next to main
         run: |
           git fetch --unshallow
           git checkout next

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -1,4 +1,4 @@
-name: Update alpha
+name: Update next
 on:
   workflow_run:
     workflows:
@@ -15,6 +15,6 @@ jobs:
       - name: Rebase alpha to main
         run: |
           git fetch --unshallow
-          git checkout alpha
+          git checkout next
           git rebase origin/main
           git push

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,6 @@
 {
     "branches": [
       { "name": "main" },
-      { "name": "alpha", "prerelease": true },
       { "name": "next", "prerelease": true }
     ],
     "plugins": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ npm install -g pnpm
 Install dependencies by running:
 
 ```sh
-pnpm i
+pnpm install
 ```
 
 ## Contributing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,10 @@ which for now only consist of a set of required resets based on the
 
 To get an overview of the project, read the [README](README.md).
 
-
 ## Development Setup
 
 To get started with developing [@warp-ds/css](https://github.com/warp-ds/css), follow the instructions below.
 This will walk you through setting up your development environment.
-
 
 ### Cloning the repository
 
@@ -25,7 +23,6 @@ Start by cloning the repository to your dev environment by running:
 git clone https://github.com/warp-ds/css
 ```
 
-
 ### pnpm
 
 We use [pnpm](https://pnpm.io/) as package manager for Node.js.
@@ -34,7 +31,6 @@ Install it by running:
 ```sh
 npm install -g pnpm
 ```
-
 
 ### Dependencies
 
@@ -49,11 +45,12 @@ pnpm i
 ### Branching
 
 There are two branches to keep in mind:
-- `alpha` : used for pre-releases.
+
+- `next` : used for pre-releases.
 - `main` : the main branch, used for stable releases.
 
 When adding a new feature, fixing a bug, or adding to the repository in any other way,
-you should always do this in a feature branch that is branched off the `alpha` branch.
+you should always do this in a feature branch that is branched off the `next` branch.
 
 ### Committing
 
@@ -62,10 +59,10 @@ as this is used in the [automated release process](#releases).
 
 ### Pull Request
 
-When your changes are ready for pull request, this should be opened against the `alpha` branch.
+When your changes are ready for pull request, this should be opened against the `next` branch.
 Add the [Warp Core Team](https://github.com/orgs/warp-ds/teams/warp-core-team) as reviewer.
 
-Pull request to the `alpha` branch should always be set to *squash*.
+Pull request to the `next` branch should always be set to _squash_.
 Make sure that the squash commit message follows the instructions in the [Committing](#committing) section before squash merging the pull request.
 
 ### Commitizen
@@ -82,26 +79,20 @@ When installed, you should be able to type `cz` or `git cz` in your terminal to 
 
 [![Add and commit with Commitizen](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)
 
-
 ## Releases
 
 This project uses [Semantic Release](https://github.com/semantic-release/semantic-release) to automate package
-publishing when making changes to the `main` or `alpha` branch.
+publishing when making changes to the `main` or `next` branch.
 
 Please note that the version published will depend on your commit message structure.
 Make sure to review and follow the instructions in the [Committing](#committing) section before committing.
 
-Before the first major release we develop against an `alpha` branch which is constantly published to [Eik]( ) using an `alpha` tag (e.g. `1.0.0-alpha.1`).
-Anyone needing to start using the package before the first major release can install the `alpha` version while waiting for the first stable version.
+A stable release from the `main` branch is basically done by just opening a pull request from `next` to `main` and then make sure to _merge_ commit the pull request.
+Never squash to `main` to prevent losing history and commit messages from all commits to `next`.
 
-TODO: When the first stable release is done, the `alpha` branch should possibly be renamed `next` to implement releasing a `next` tag from that branch instead of `alpha`.
-
-A stable release from the `main` branch is basically done by just opening a pull request from `alpha` to `main` and then make sure to *merge* commit the pull request.
-Never squash to `main` to prevent losing history and commit messages from all commits to `alpha`.
-
-To avoid git history divergence between `alpha` and `main`,
+To avoid git history divergence between `next` and `main`,
 when a stable release from `main` results in a semantic-release-bot commit being pushed to `main`,
-a GitHub action automatically rebase `alpha` to `origin/main` after every release from `main`.
+a GitHub action automatically rebase `next` to `origin/main` after every release from `main`.
 
 ( For reference, see this rfc in Fabric-ds: [RFC: Fabric Releases and Release Schedule](https://github.com/fabric-ds/issues/blob/779d59723993c13d62374516259602d967da56ca/rfcs/0004-releases.md) )
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,7 @@ pnpm i
 ### Branching
 
 There are two branches to keep in mind:
-
-- `next` : used for pre-releases.
+- `next` : default, used for pre-releases.
 - `main` : the main branch, used for stable releases.
 
 When adding a new feature, fixing a bug, or adding to the repository in any other way,
@@ -86,6 +85,9 @@ publishing when making changes to the `main` or `next` branch.
 
 Please note that the version published will depend on your commit message structure.
 Make sure to review and follow the instructions in the [Committing](#committing) section before committing.
+
+This project is continuously published to [NPM](https://www.npmjs.com/package/@warp-ds/drive) and [Eik](https://assets.finn.no/pkg/@warp-ds/css) using a `next` tag (e.g. `1.1.0-next.1`).
+Anyone needing to use the latest changes of this package can point to the `next` version while waiting for the stable release.
 
 A stable release from the `main` branch is basically done by just opening a pull request from `next` to `main` and then make sure to _merge_ commit the pull request.
 Never squash to `main` to prevent losing history and commit messages from all commits to `next`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We publish 3 css files.
 Only component classes are published to npm to be used in the component libraries.
 
 ```sh
-pnpm install @warp-ds/css
+pnpm add @warp-ds/css
 ```
 
 ### Component classes


### PR DESCRIPTION
[WARP-209](https://nmp-jira.atlassian.net/browse/WARP-209): Update `contributing.md` file after we change from using alpha to next branch + update github workflows to use `next` instead of `alpha`

- [x] Update branch settings