### PR TITLE
fix(buttons.yml): remove unused color-button-disabled-quiet- tokens

### DIFF
--- a/tokens/blocket.se/buttons.yml
+++ b/tokens/blocket.se/buttons.yml
@@ -58,7 +58,7 @@ color:
       text: s-color-text-inverted
       background: s-color-background-disabled
       quiet:
-        text: s-color-text-link-disabled
+        text: s-color-text-disabled
         border: s-color-border-disabled
     link:
       text: s-color-text-link

--- a/tokens/blocket.se/buttons.yml
+++ b/tokens/blocket.se/buttons.yml
@@ -57,9 +57,6 @@ color:
     disabled:
       text: s-color-text-inverted
       background: s-color-background-disabled
-      quiet:
-        text: s-color-text-disabled
-        border: s-color-border-disabled
     link:
       text: s-color-text-link
     pill:

--- a/tokens/finn.no/buttons.yml
+++ b/tokens/finn.no/buttons.yml
@@ -58,7 +58,7 @@ color:
       text: s-color-text-inverted
       background: s-color-background-disabled
       quiet:
-        text: s-color-text-link-disabled
+        text: s-color-text-disabled
         border: s-color-border-disabled
     link:
       text: s-color-text-link

--- a/tokens/finn.no/buttons.yml
+++ b/tokens/finn.no/buttons.yml
@@ -57,9 +57,6 @@ color:
     disabled:
       text: s-color-text-inverted
       background: s-color-background-disabled
-      quiet:
-        text: s-color-text-disabled
-        border: s-color-border-disabled
     link:
       text: s-color-text-link
     pill:

--- a/tokens/tori.fi/buttons.yml
+++ b/tokens/tori.fi/buttons.yml
@@ -58,7 +58,7 @@ color:
       text: s-color-text-inverted
       background: s-color-background-disabled
       quiet:
-        text: s-color-text-link-disabled
+        text: s-color-text-disabled
         border: s-color-border-disabled
     link:
       text: s-color-text-link

--- a/tokens/tori.fi/buttons.yml
+++ b/tokens/tori.fi/buttons.yml
@@ -57,9 +57,6 @@ color:
     disabled:
       text: s-color-text-inverted
       background: s-color-background-disabled
-      quiet:
-        text: s-color-text-disabled
-        border: s-color-border-disabled
     link:
       text: s-color-text-link
     pill:


### PR DESCRIPTION
Consulted with @adidick.
All button variants use the same disabled tokens so the `disabled-quiet-` tokens can be removed. They weren't in use so it's  not a breaking change.