### PR TITLE
fix: set cursor to default for non-interactive affixes

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -357,14 +357,14 @@ export const suffix = {
   wrapper: prefixSuffixWrapperBase + 'right-0',
   wrapperWithLabel: 'w-max pr-12',
   wrapperWithIcon: 'w-40',
-  label: `${label.label} pb-0! text-xs!`,
+  label: 'antialiased block relative cursor-default pb-0 font-bold text-xs i-text-$color-label-text',
 };
 
 export const prefix = {
   wrapper: prefixSuffixWrapperBase + 'left-0',
   wrapperWithLabel: 'w-max pl-12',
   wrapperWithIcon: 'w-40',
-  label: `${label.label} pb-0! text-xs!`,
+  label: 'antialiased block relative cursor-default pb-0 font-bold text-xs i-text-$color-label-text',
 };
 
 export const breadcrumbs = {


### PR DESCRIPTION
Affixes that are not interactive should have `cursor: default;`, while `label.label` classes that were used before would include `cursor-pointer`. This PR fixes it by setting `cursor-default` on suffix and prefix `label` classes. When an affix is interactive, it renders as button, which then gets `cursor: pointer;` by default, so we don't need to do anything here.

Not referencing `label.label` classes allowed to remove the `!` rules from `text-xs` and `pb-0`, too. This way we have more control over the applied styles.

Before:
![affix-issue](https://github.com/warp-ds/css/assets/41303231/4ad17caa-995c-43f3-b0c1-33a749734615)

After
![affix-fix](https://github.com/warp-ds/css/assets/41303231/0b53b8ac-67ec-4f94-b128-ac642f746805)

