### PR TITLE
chore(readme.md): show Eik urls pointing at v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The CSS files should be used directly from Eik. This is because we can alias rel
 
 We publish 3 css files.
 
-- Resets <link href="https://assets.finn.no/pkg/@warp-ds/css/[VERSION]/resets.css" rel="stylesheet" />
-- Components css <link href="https://assets.finn.no/pkg/@warp-ds/css/[VERSION]/components.css" rel="stylesheet" />
-- Brand css with tokens <link href="https://assets.finn.no/pkg/@warp-ds/css/[VERSION]/tokens/[BRANDNAME e.g. tori-fi].css" rel="stylesheet" />  
+- Resets: `https://assets.finn.no/pkg/@warp-ds/css/v1/resets.css`
+- Components css: `https://assets.finn.no/pkg/@warp-ds/css/v1/components.css`
+- Brand css with tokens: `https://assets.finn.no/pkg/@warp-ds/css/v1/tokens/[BRANDNAME e.g. tori-fi].css`
 
 ## Usage (npm)
 


### PR DESCRIPTION
Before:
<img width="572" alt="Screenshot 2023-08-31 at 15 08 18" src="https://github.com/warp-ds/css/assets/41303231/e23ddf59-f5b8-44fc-a293-20d72f6caa1e">

After:
<img width="554" alt="Screenshot 2023-08-31 at 15 08 07" src="https://github.com/warp-ds/css/assets/41303231/0f99be7d-d9f4-4a56-8d49-665945acc0ca">

I thought it's better to show that we have an alias (v1) in Eik. That should prevent people from using specific versions by default. If for some reason they need a specific version, they'll replace that v1, I believe.