### PR TITLE
fix: Updated background colors for badge variants

### DIFF
--- a/tokens/finn.no/badge.yml
+++ b/tokens/finn.no/badge.yml
@@ -5,19 +5,19 @@ color:
   badge:
     neutral:
       text: s-color-text
-      background: gray-100
+      background: bluegray-100
     info:
       text: s-color-text
-      background: s-color-background-info-subtle
+      background: aqua-100
     positive:
       text: s-color-text
-      background: s-color-background-positive-subtle
+      background: green-100
     warning:
       text: s-color-text
-      background: s-color-background-warning-subtle
+      background: yellow-100
     negative:
       text: s-color-text
-      background: s-color-background-negative-subtle
+      background: red-100
     disabled:
       text: s-color-text
       background: s-color-background-disabled

--- a/tokens/tori.fi/badge.yml
+++ b/tokens/tori.fi/badge.yml
@@ -8,16 +8,16 @@ color:
       background: gray-100
     info:
       text: s-color-text
-      background: s-color-background-info-subtle
+      background: petroleum-100
     positive:
       text: s-color-text
-      background: s-color-background-positive-subtle
+      background: green-100
     warning:
       text: s-color-text
-      background: s-color-background-warning-subtle
+      background: yellow-100
     negative:
       text: s-color-text
-      background: s-color-background-negative-subtle
+      background: red-100
     disabled:
       text: s-color-text
       background: s-color-background-disabled


### PR DESCRIPTION
Updated Finn and Tori colors for the badge according to changes in:
https://docs.google.com/spreadsheets/d/1Q-Tr_dwJVfxgh3527IFjXQKqtnPPM42QeIr-M6q-zu8/edit?pli=1#gid=1588196525