### PR TITLE
refactor: adjust padding + font-size for ccPill.close

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -86,6 +86,7 @@ export namespace pill {
     const labelWithoutClose: string;
     const labelWithClose: string;
     const close: string;
+    const closeX: string;
     const a11y: string;
 }
 export namespace step {

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -86,7 +86,6 @@ export namespace pill {
     const labelWithoutClose: string;
     const labelWithClose: string;
     const close: string;
-    const closeX: string;
     const a11y: string;
 }
 export namespace step {

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -93,7 +93,7 @@ export const pill = {
   label: 'pl-12 py-8 rounded-l-full',
   labelWithoutClose: 'pr-12 rounded-r-full',
   labelWithClose: 'pr-2',
-  close: 'pr-12 pl-4 pt-4 pb-6 rounded-r-full text-m',
+  close: 'pr-12 pl-4 pt-4 pb-6 rounded-r-full !text-m',
   a11y: 'sr-only',
 };
 

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -93,7 +93,7 @@ export const pill = {
   label: 'pl-12 py-8 rounded-l-full',
   labelWithoutClose: 'pr-12 rounded-r-full',
   labelWithClose: 'pr-2',
-  close: 'pr-12 pl-4 py-10 rounded-r-full',
+  close: 'pr-12 pl-4 pt-4 pb-6 rounded-r-full text-m',
   a11y: 'sr-only',
 };
 

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -93,8 +93,7 @@ export const pill = {
   label: 'pl-12 py-8 rounded-l-full',
   labelWithoutClose: 'pr-12 rounded-r-full',
   labelWithClose: 'pr-2',
-  close: 'pr-12 pl-4 py-10 rounded-r-full',
-  closeX: 'pr-12 pl-4 pt-4 pb-6 rounded-r-full text-m!',
+  close: 'pr-12 pl-4 pt-4 pb-6 rounded-r-full text-m!',
   a11y: 'sr-only',
 };
 

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -93,7 +93,8 @@ export const pill = {
   label: 'pl-12 py-8 rounded-l-full',
   labelWithoutClose: 'pr-12 rounded-r-full',
   labelWithClose: 'pr-2',
-  close: 'pr-12 pl-4 pt-4 pb-6 rounded-r-full !text-m',
+  close: 'pr-12 pl-4 py-10 rounded-r-full',
+  closeX: 'pr-12 pl-4 pt-4 pb-6 rounded-r-full text-m!',
   a11y: 'sr-only',
 };
 


### PR DESCRIPTION
Have to adjust the padding and font-size since we are replacing the inline-svg in the pill-component with a letter 'x'.

Test by linking to branch `refactor/replace-inline-svgs-with-warp-icons` in vue-repo and react-repo:
vue-repo:  https://github.com/warp-ds/vue/pull/78
React-repo: https://github.com/warp-ds/react/pull/95