### PR TITLE
fix: skip resets in components.css

### DIFF
--- a/component-classes/vite.config.js
+++ b/component-classes/vite.config.js
@@ -1,5 +1,5 @@
 /* eslint-env node */
-import dts from "vite-plugin-dts";
+import dts from 'vite-plugin-dts';
 import { presetWarp } from '@warp-ds/uno';
 import uno from 'unocss/vite';
 import { classes } from './classes.js';
@@ -7,7 +7,7 @@ import { classes } from './classes.js';
 export default () => ({
   plugins: [
     uno({
-      presets: [presetWarp({ skipPreflight: true })],
+      presets: [presetWarp({ skipResets: true })],
       mode: 'dist-chunk',
       safelist: classes,
     }),


### PR DESCRIPTION
We have removed `skipPreflight` options since before, need to use `skipResets` instead
Before|After
---|---
![image](https://github.com/warp-ds/css/assets/37986637/ca86484b-9d29-4f69-8c8c-306562b24dbe)|![image](https://github.com/warp-ds/css/assets/37986637/7cdfa997-7130-42a0-8ed0-3dc7fa2bb46a)
