### PR TITLE
fix(alert): override font-size/line-height of h3 title in Vue Alert

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -413,7 +413,7 @@ export const alert = {
   alert: "flex p-16 border border-l-4 rounded-4",
   willChangeHeight: "will-change-height",
   textWrapper: "last-child:mb-0 text-s",
-  title: "font-bold",
+  title: "text-s",
   icon: "w-16 mr-8 min-w-16",
   negative:  "i-border-$color-alert-negative-subtle-border i-bg-$color-alert-negative-background i-text-$color-alert-negative-text i-border-l-$color-alert-negative-border",
   negativeIcon: "i-text-$color-alert-negative-icon",


### PR DESCRIPTION
Alert title should be a heading to ensure accessibility. In @warp-ds/vue Alert accepts a title prop, which will now be a `h3` instead of a `p` with bold font-weight, so in order for that to have the same size as `p`, we need to assign that heading element a 'text-s' class.

A corresponding fix is on its way in @warp-ds/vue once this PR is merged and released.