### PR TITLE
fix(button): set p-0 on any button of type link

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -273,7 +273,7 @@ const buttonSizes = {
   smallUtility: 'py-[7px] px-[15px]',
   pill: 'min-h-[44px] min-w-[44px]',
   pillSmall: 'min-h-32 min-w-32',
-  linkSmall: 'p-0',
+  link: 'p-0',
 };
 
 const buttonTextSizes = {
@@ -359,8 +359,8 @@ export const button = {
   pillLoading: `${buttonSizes.pill} ${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonVariants.inProgress}`,
   pillSmallLoading: `${buttonSizes.pillSmall} ${buttonTextSizes.xsmall} ${buttonTypes.pill} ${buttonVariants.inProgress}`,
 
-  link: `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.link}`,
-  linkSmall: `${buttonSizes.linkSmall} ${buttonTextSizes.xsmall} ${buttonTypes.link}`,
+  link: `${buttonSizes.link} ${buttonTextSizes.medium} ${buttonTypes.link}`,
+  linkSmall: `${buttonSizes.link} ${buttonTextSizes.xsmall} ${buttonTypes.link}`,
   linkAsButton: 'inline-block hover:no-underline',
   a11y: 'sr-only',
   fullWidth: "w-full max-w-full",


### PR DESCRIPTION
Fixes [WARP-343](https://nmp-jira.atlassian.net/browse/WARP-343)

Tested in React with `npm link` and it looks correct now.

**Before:**
<img width="322" alt="react button link with large paddings" src="https://github.com/warp-ds/css/assets/41303231/cc87b155-33e9-43e4-8757-8f1cb73195d8">

**After:**
<img width="331" alt="react button link with no padding" src="https://github.com/warp-ds/css/assets/41303231/0fcea11b-b63b-48ef-aebd-1c536141e0e9">
