### PR TITLE
fix(button): add text-center to buttonAsLink

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -361,7 +361,7 @@ export const button = {
 
   link: `${buttonSizes.link} ${buttonTextSizes.medium} ${buttonTypes.link}`,
   linkSmall: `${buttonSizes.link} ${buttonTextSizes.xsmall} ${buttonTypes.link}`,
-  linkAsButton: 'inline-block hover:no-underline',
+  linkAsButton: 'inline-block hover:no-underline text-center',
   a11y: 'sr-only',
   fullWidth: "w-full max-w-full",
   contentWidth: "max-w-max",


### PR DESCRIPTION
FIxes [WARP-347](https://nmp-jira.atlassian.net/browse/WARP-347)

Buttons rendered as links will now have the text centered.

Example from React:

Before:
![Screenshot 2023-10-13 at 12 32 39](https://github.com/warp-ds/css/assets/41303231/c6dce7a9-a9cd-4080-b6ac-4da8bc9f774b)

After:
![Screenshot 2023-10-13 at 12 32 02](https://github.com/warp-ds/css/assets/41303231/f113e433-9a39-44af-8d8f-7563ee7f2c5f)
