### PR TITLE
chore: remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "./component-classes/index.d.ts"
   ],
   "dependencies": {
-    "@warp-ds/fonts": "1.1.0",
     "@warp-ds/tokenizer": "^0.0.2",
     "@warp-ds/uno": "^1.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@warp-ds/fonts':
-    specifier: 1.1.0
-    version: 1.1.0
   '@warp-ds/tokenizer':
     specifier: ^0.0.2
     version: 0.0.2
@@ -1324,10 +1321,6 @@ packages:
     dependencies:
       eslint: 8.43.0
     dev: true
-
-  /@warp-ds/fonts@1.1.0:
-    resolution: {integrity: sha512-kLNZzK3o0rMJApm7/YT3K7rYoFKgH5PyJMTVwv34O4Dx6ikfN7appc4f2DFYkE2XY6gifpD5F2r1ftcJtdW4+w==}
-    dev: false
 
   /@warp-ds/tokenizer@0.0.2:
     resolution: {integrity: sha512-pEtBvP6my14f1kOmYSoDNhofGK/L2yNqnZkEotvY6boVs3jcIncHpgo9Nt4AHOiAvzDrPP0t8b36jwqGaWzNPg==}


### PR DESCRIPTION
Usage of the fonts were removed here https://github.com/warp-ds/css/commit/643028f63b9e147681715334e765aab2fe8d0a58 so I think we can remove this dependency