### PR TITLE
feat(component-classes): add 'highlight' variant to attention classes

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -2,6 +2,7 @@ export namespace attention {
     const base: string;
     const tooltip: string;
     const callout: string;
+    const highlight: string;
     const popover: string;
     const arrowBase: string;
     const arrowDirectionLeft: string;
@@ -11,6 +12,7 @@ export namespace attention {
     const arrowTooltip: string;
     const arrowCallout: string;
     const arrowPopover: string;
+    const arrowHighlight: string;
     const content: string;
     const notCallout: string;
 }

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -3,6 +3,7 @@ export const attention = {
   tooltip:
     'i-bg-$color-tooltip-background i-border-$color-tooltip-background i-shadow-$shadow-tooltip i-text-$color-tooltip-text rounded-4 py-6 px-8',
   callout: 'i-bg-$color-callout-background i-border-$color-callout-border i-text-$color-callout-text py-8 px-16 rounded-8',
+  highlight: 'i-bg-$color-callout-background i-border-$color-callout-border i-text-$color-callout-text py-8 px-16 rounded-8 drop-shadow-m',
   popover:
     'i-bg-$color-popover-background i-border-$color-popover-background i-text-$color-popover-paragraph-text rounded-8 p-16 drop-shadow-m',
   arrowBase:
@@ -14,6 +15,7 @@ export const attention = {
   arrowTooltip: 'i-bg-$color-tooltip-background i-border-$color-tooltip-background',
   arrowCallout: 'i-bg-$color-callout-background i-border-$color-callout-border',
   arrowPopover: 'i-bg-$color-popover-background i-border-$color-popover-background',
+  arrowHighlight: 'i-bg-$color-callout-background i-border-$color-callout-border',
   content: 'last-child:mb-0',
   notCallout: 'absolute z-50',
 };


### PR DESCRIPTION
Adds classes used in an Attention component of `highlight` variant. They reuse callout tokens because we may soon go away from the component level tokens, and adding another component token type isn't necessary.

<img width="406" alt="example of highlight attention component" src="https://github.com/warp-ds/css/assets/41303231/c08e2c8c-0fc7-4eeb-b1d5-351b5be4b40a">

