### PR TITLE
fix: Z-index of Modal backdrop should be 30 according to css docs

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -376,7 +376,7 @@ export const modal = {
   //TODO: this class can be removed when we have the solution for opacity and we can add rgba values to the background of the backdrop
   transparentBg: `before:i-bg-$color-modal-backdrop-background before:content-[""] before:absolute before:top-0 before:bottom-0 before:left-0 before:right-0 before:opacity-25`,
   backdrop:
-    'fixed inset-0 flex sm:place-content-center sm:place-items-center items-end z-20 [--w-modal-max-height:80%] [--w-modal-width:640px]',
+    'fixed inset-0 flex sm:place-content-center sm:place-items-center items-end z-30 [--w-modal-max-height:80%] [--w-modal-width:640px]',
   modal:
     'pb-safe-[32] i-shadow-$shadow-modal max-h-[--w-modal-max-height] min-h-[--w-modal-min-height] w-[--w-modal-width] h-[--w-modal-height] relative transition-300 ease-in-out backface-hidden will-change-height rounded-8 mx-0 sm:mx-16 i-bg-$color-modal-background flex flex-col overflow-hidden outline-none space-y-16 pt-8 sm:pt-32 sm:pb-32 rounded-b-0 sm:rounded-b-8',
   content:


### PR DESCRIPTION
The modal overlay has a z-index of 20... But reading the css-docs it says it should be 30.
There is a bug in tech-docs because it clashes with the z-index levels of VitePress, changing it to z-30 will solve it there as well.
https://warp-ds.github.io/tech-docs/components/modal/
https://warp-ds.github.io/css-docs/z-index 

![image](https://github.com/warp-ds/css/assets/7531505/f35f162a-b684-4c35-be23-dc8875cb7496)
![image](https://github.com/warp-ds/css/assets/7531505/ab983be1-3bd4-4790-830a-e0a21376156a)
