### PR TITLE
fix(cc): restore styles for deprecated z-20 class

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -478,3 +478,6 @@ export namespace attention {
     export const notCallout: string;
     export const closeBtn: string;
 }
+export namespace backwardsCompatibleClasses {
+    const modalBackdrop: string;
+}

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -544,3 +544,7 @@ export const attention = {
   notCallout: 'absolute z-50',
   closeBtn: `${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill} justify-self-end -mr-8 ml-8`,
 };
+
+export const backwardsCompatibleClasses = {
+  modalBackdrop: 'z-20', // replaced by z-30 in v1.4.0
+};


### PR DESCRIPTION
Whenever we need to replace a unique class from the component classes list, we should make sure it doesn't break apps that rely on that class being styled until @warp-ds/css dependency is updated. This can happen when those apps get styles from `components.css` available on Eik under https://assets.finn.no/pkg/@warp-ds/css/v1/components.css.