### PR TITLE
fix: add style to a-tag in resets.js

### DIFF
--- a/resets/resets.js
+++ b/resets/resets.js
@@ -100,12 +100,19 @@ a {
   cursor: pointer;
   text-decoration: none;
   color: var(--w-s-color-text-link);
+  line-height: 2.4rem;
+  display: flex;
+  text-align: center;
+  align-items: center;
 }
 
 a:hover,
 a:focus,
 a:active {
   text-decoration: var(--w-decoration-text-link);
+}
+a:focus-visible {
+  outline: 2px solid var(--w-s-color-focused);
 }
 
 /*


### PR DESCRIPTION
This fix is related to Jira ticket [WARP-382](https://nmp-jira.atlassian.net/browse/WARP-382).

After discussions we have decided to not recommend using button with both link and href-props activated. We instead recommend the use of an anchor-tag. However we needed to add additional style for our anchor-tags to have the same outline-style as the button with link-prop has. 

- Updated the style for <a>-tag in resets.js

<img width="98" alt="Skärmavbild 2023-11-21 kl  15 56 54" src="https://github.com/warp-ds/css/assets/144792260/edd29621-b4a0-4863-86e7-97529446f86f">

