### PR TITLE
fix: remove styling from a-tag including line-height + flex

### DIFF
--- a/resets/resets.js
+++ b/resets/resets.js
@@ -100,10 +100,6 @@ a {
   cursor: pointer;
   text-decoration: none;
   color: var(--w-s-color-text-link);
-  line-height: 2.4rem;
-  display: flex;
-  text-align: center;
-  align-items: center;
 }
 
 a:hover,


### PR DESCRIPTION
Related to previously merged PR: https://github.com/warp-ds/css/pull/97 

- Remove line-height + display: flex, in order to avoid risk of breaking changes