### PR TITLE
fix(tokens): move focused color to border-focused token

### DIFF
--- a/tokens/blocket.se/semantic.yml
+++ b/tokens/blocket.se/semantic.yml
@@ -12,6 +12,7 @@ s:
         _: blue-50
         hover: blue-100
       disabled: bluegray-300
+      focused: aqua-400
       inverted: gray-900
       subtle:
         _: bluegray-50

--- a/tokens/finn.no/semantic.yml
+++ b/tokens/finn.no/semantic.yml
@@ -80,6 +80,7 @@ s:
       hover: bluegray-400
       active: bluegray-500
       disabled: bluegray-300
+      focused: aqua-400
       selected:
         _: blue-600
         hover: blue-700

--- a/tokens/tori.fi/semantic.yml
+++ b/tokens/tori.fi/semantic.yml
@@ -80,6 +80,7 @@ s:
       hover: gray-400
       active: gray-500
       disabled: gray-300
+      focused: petroleum-400
       selected:
         _: petroleum-600
         hover: petroleum-700


### PR DESCRIPTION
Fixes [WARP-398](https://nmp-jira.atlassian.net/browse/WARP-398):

We should allow users to style the color of the outline in the same way as they can style border - using semantic color classes. We can for the time being reuse border color tokens, but since the focused outline color is currently assigned to a generic `--w-s-color-focused` token, we thought it’s better to have it as  `--w-s-color-border-focused` to make the border and outline color rules aligned.

We're keeping the generic `focused` token for backward compatibility.