### PR TITLE
fix(cc): Restore styles for deprecated right-16 left-8

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -479,5 +479,9 @@ export namespace attention {
     export const closeBtn: string;
 }
 export namespace backwardsCompatibleClasses {
-    const modalBackdrop: string;
+    export const modalBackdrop: string;
+    const chevronBox_1: string;
+    export { chevronBox_1 as chevronBox };
+    const chevronNonBox_1: string;
+    export { chevronNonBox_1 as chevronNonBox };
 }

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -547,4 +547,6 @@ export const attention = {
 
 export const backwardsCompatibleClasses = {
   modalBackdrop: 'z-20', // replaced by z-30 in v1.4.0
+  chevronBox: 'right-16', //removed in v1.4.0
+  chevronNonBox: 'left-8', //removed in v1.4.0
 };


### PR DESCRIPTION
After releasing https://github.com/warp-ds/css/pull/89 to [eik](https://assets.finn.no/pkg/@warp-ds/css/v1/components.css) we removed styles for `right-16` and `left-8` classes. This broke styles of expandable's chevron (@warp-ds/elements) that still imports the old classes while pulling styles from Eik. The result looks like this:
<img width="294" alt="Screenshot 2023-11-24 at 12 20 13" src="https://github.com/warp-ds/css/assets/41303231/c5fcd01c-2917-4bb4-b5d6-920b5e8b298c">
<img width="156" alt="Screenshot 2023-11-24 at 12 20 17" src="https://github.com/warp-ds/css/assets/41303231/e7562009-963f-483c-ae7f-8eb4d349f797">

This PR restores the two classes as part of the backward compatible list.
