### PR TITLE
Release 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.4.2-next.4](https://github.com/warp-ds/css/compare/v1.4.2-next.3...v1.4.2-next.4) (2023-11-24)
+
+
+### Bug Fixes
+
+* **cc:** Restore styles for deprecated right-16 left-8 ([#101](https://github.com/warp-ds/css/issues/101)) ([393310a](https://github.com/warp-ds/css/commit/393310a589aa46e8a9515ff16f6de73256f5515a))
+
 ## [1.4.2-next.3](https://github.com/warp-ds/css/compare/v1.4.2-next.2...v1.4.2-next.3) (2023-11-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.4.2-next.3](https://github.com/warp-ds/css/compare/v1.4.2-next.2...v1.4.2-next.3) (2023-11-24)
+
+
+### Bug Fixes
+
+* **tokens:** move focused color to border-focused token ([#100](https://github.com/warp-ds/css/issues/100)) ([ff35a83](https://github.com/warp-ds/css/commit/ff35a8333f462231ad51d24c7907b66446f14a3c))
+
 ## [1.4.2-next.2](https://github.com/warp-ds/css/compare/v1.4.2-next.1...v1.4.2-next.2) (2023-11-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.4.2-next.1](https://github.com/warp-ds/css/compare/v1.4.1...v1.4.2-next.1) (2023-11-22)
+
+
+### Bug Fixes
+
+* add style to a-tag in resets.js ([#97](https://github.com/warp-ds/css/issues/97)) ([5fdeb4d](https://github.com/warp-ds/css/commit/5fdeb4d381424ec7c072843fbfe87d88c2f5855e))
+
 ## [1.4.1](https://github.com/warp-ds/css/compare/v1.4.0...v1.4.1) (2023-11-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.4.2-next.2](https://github.com/warp-ds/css/compare/v1.4.2-next.1...v1.4.2-next.2) (2023-11-22)
+
+
+### Reverts
+
+* Revert "fix: add style to a-tag in resets.js (#97)" (#99) ([bbf385c](https://github.com/warp-ds/css/commit/bbf385c3933c0f510cbd339a58193df8077d9fe8)), closes [#97](https://github.com/warp-ds/css/issues/97) [#99](https://github.com/warp-ds/css/issues/99)
+
 ## [1.4.2-next.1](https://github.com/warp-ds/css/compare/v1.4.1...v1.4.2-next.1) (2023-11-22)
 
 

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -479,5 +479,9 @@ export namespace attention {
     export const closeBtn: string;
 }
 export namespace backwardsCompatibleClasses {
-    const modalBackdrop: string;
+    export const modalBackdrop: string;
+    const chevronBox_1: string;
+    export { chevronBox_1 as chevronBox };
+    const chevronNonBox_1: string;
+    export { chevronNonBox_1 as chevronNonBox };
 }

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -547,4 +547,6 @@ export const attention = {
 
 export const backwardsCompatibleClasses = {
   modalBackdrop: 'z-20', // replaced by z-30 in v1.4.0
+  chevronBox: 'right-16', //removed in v1.4.0
+  chevronNonBox: 'left-8', //removed in v1.4.0
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@warp-ds/css",
   "repository": "git@github.com:warp-ds/css.git",
-  "version": "1.4.1",
+  "version": "1.4.2-next.1",
   "scripts": {
     "build": "pnpm build:tokens && pnpm build:resets && pnpm build:cc",
     "commit": "cz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@warp-ds/css",
   "repository": "git@github.com:warp-ds/css.git",
-  "version": "1.4.2-next.1",
+  "version": "1.4.2-next.2",
   "scripts": {
     "build": "pnpm build:tokens && pnpm build:resets && pnpm build:cc",
     "commit": "cz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@warp-ds/css",
   "repository": "git@github.com:warp-ds/css.git",
-  "version": "1.4.2-next.3",
+  "version": "1.4.2-next.4",
   "scripts": {
     "build": "pnpm build:tokens && pnpm build:resets && pnpm build:cc",
     "commit": "cz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@warp-ds/css",
   "repository": "git@github.com:warp-ds/css.git",
-  "version": "1.4.2-next.2",
+  "version": "1.4.2-next.3",
   "scripts": {
     "build": "pnpm build:tokens && pnpm build:resets && pnpm build:cc",
     "commit": "cz",

--- a/resets/resets.js
+++ b/resets/resets.js
@@ -100,19 +100,12 @@ a {
   cursor: pointer;
   text-decoration: none;
   color: var(--w-s-color-text-link);
-  line-height: 2.4rem;
-  display: flex;
-  text-align: center;
-  align-items: center;
 }
 
 a:hover,
 a:focus,
 a:active {
   text-decoration: var(--w-decoration-text-link);
-}
-a:focus-visible {
-  outline: 2px solid var(--w-s-color-focused);
 }
 
 /*

--- a/resets/resets.js
+++ b/resets/resets.js
@@ -100,12 +100,19 @@ a {
   cursor: pointer;
   text-decoration: none;
   color: var(--w-s-color-text-link);
+  line-height: 2.4rem;
+  display: flex;
+  text-align: center;
+  align-items: center;
 }
 
 a:hover,
 a:focus,
 a:active {
   text-decoration: var(--w-decoration-text-link);
+}
+a:focus-visible {
+  outline: 2px solid var(--w-s-color-focused);
 }
 
 /*

--- a/tokens/blocket.se/semantic.yml
+++ b/tokens/blocket.se/semantic.yml
@@ -12,6 +12,7 @@ s:
         _: blue-50
         hover: blue-100
       disabled: bluegray-300
+      focused: aqua-400
       inverted: gray-900
       subtle:
         _: bluegray-50

--- a/tokens/finn.no/semantic.yml
+++ b/tokens/finn.no/semantic.yml
@@ -80,6 +80,7 @@ s:
       hover: bluegray-400
       active: bluegray-500
       disabled: bluegray-300
+      focused: aqua-400
       selected:
         _: blue-600
         hover: blue-700

--- a/tokens/tori.fi/semantic.yml
+++ b/tokens/tori.fi/semantic.yml
@@ -80,6 +80,7 @@ s:
       hover: gray-400
       active: gray-500
       disabled: gray-300
+      focused: petroleum-400
       selected:
         _: petroleum-600
         hover: petroleum-700


### PR DESCRIPTION
We should update [components.css](https://assets.finn.no/pkg/@warp-ds/css/1.4.1/components.css) that no longer includes styles for `right-16` and `left-8` classes. We accidentally introduced a breaking change, which this release will fix.