### PR TITLE
fix(package.json): publish /dist folder to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     }
   },
   "files": [
+    "dist",
     "./component-classes/index.js",
     "./component-classes/classes.js",
     "./component-classes/shortcuts.js",


### PR DESCRIPTION
Fixes [WARP-425](https://nmp-jira.atlassian.net/browse/WARP-425)

This change will make it possible to publish assets from this package to Eik using an external repo ([eik-shared-libs](https://github.com/finn-no/eik-shared-libs)).

Note: When eik publishing of the css package is handled in eik-shared-libs (`warp-ds-css` is added to [the list of packages there](https://github.com/finn-no/eik-shared-libs/tree/main/packages)), we will be able to remove all references to Eik from this package. Until then, we can carry out Eik publishing through the Release workflow as before.