### PR TITLE
fix(cc): set default background on unselected card

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -104,6 +104,7 @@ export namespace card {
     export const cardFlat: string;
     export const cardFlatUnselected: string;
     export const cardFlatSelected: string;
+    export const cardUnselected: string;
     export const cardSelected: string;
     export const cardOutline: string;
     export const cardOutlineUnselected: string;

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -118,6 +118,7 @@ export const card = {
     'i-bg-$color-card-flat-background i-border-$color-card-flat-border hover:i-bg-$color-card-flat-background-hover hover:i-border-$color-card-flat-border-hover active:i-bg-$color-card-flat-background-active active:i-border-$color-card-flat-border-active',
   cardFlatSelected:
     'i-border-$color-card-flat-border-selected i-bg-$color-card-flat-background-selected hover:i-bg-$color-card-flat-background-selected-hover hover:i-border-$color-card-flat-border-selected-hover active:i-border-$color-card-flat-border-active active:i-bg-$color-card-flat-background-active',
+  cardUnselected: 's-bg',
   cardSelected:
     'i-border-$color-card-border-selected i-bg-$color-card-background-selected hover:i-border-$color-card-border-selected-hover hover:i-bg-$color-card-background-selected-hover active:i-border-$color-card-border-selected-active',
   cardOutline:


### PR DESCRIPTION
Fixes [WARP-430](https://nmp-jira.atlassian.net/browse/WARP-430)

Background color of a on-flat Card will no longer be inherited from the parent container.

A new key was introduced in the `card` component-classes object, because we can't set multiple classes that control background on the same element (i.e. `s-bg` and `i-bg-$color-card-background-selected`). Those selectors will have the same specificity, which could lead to `s-bg` style being applied in a selected card. In our component repos `cardSelected` and `cardUnselected` classes should be applied conditionally for non-flat cards.

Before:
<img width="475" alt="Screenshot 2023-12-19 at 13 38 04" src="https://github.com/warp-ds/css/assets/41303231/476e20a3-84da-4d9b-81b1-5bf964a0ce26">

After:
<img width="529" alt="Screenshot 2023-12-19 at 15 07 38" src="https://github.com/warp-ds/css/assets/41303231/abec61bc-731e-4c70-8e73-4fc0011b2468">
