### PR TITLE
fix: refactor modal style

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -491,4 +491,7 @@ export namespace backwardsCompatibleClasses {
     export { radioInvalid_1 as radioInvalid };
     const radioDisabled_1: string;
     export { radioDisabled_1 as radioDisabled };
+    const modal_1: string;
+    export { modal_1 as modal };
+    export const modalTitle: string;
 }

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -303,6 +303,7 @@ export namespace modal {
     export const transitionTitle: string;
     export const transitionTitleCenter: string;
     export const transitionTitleColSpan: string;
+    export const transitionTitleMaxWidth: string;
     const title_1: string;
     export { title_1 as title };
     export const titleText: string;
@@ -494,4 +495,8 @@ export namespace backwardsCompatibleClasses {
     const modal_1: string;
     export { modal_1 as modal };
     export const modalTitle: string;
+    const titleButtonLeft_1: string;
+    export { titleButtonLeft_1 as titleButtonLeft };
+    const titleButtonRight_1: string;
+    export { titleButtonRight_1 as titleButtonRight };
 }

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -386,13 +386,13 @@ export const modal = {
   transitionTitle: 'transition-all duration-300',
   transitionTitleCenter: 'justify-self-center',
   transitionTitleColSpan: 'col-span-2',
-  transitionTitleMaxWidth: 'max-w-7/8',
+  transitionTitleMaxWidth: ' max-w-6/8 md:max-w-7/8',
   title:
-    '-mt-4 sm:-mt-8 h-40 sm:h-48 grid gap-8 sm:gap-16 grid-cols-[auto_1fr_auto] items-start px-16 sm:px-32 border-b sm:border-b-0 shrink-0',
+    'pb-8 sm:pb-0 sm:-mt-8 h-40 sm:h-48 grid gap-8 sm:gap-16 grid-cols-[auto_1fr_auto] items-start px-16 sm:px-32 border-b sm:border-b-0 shrink-0',
   titleText: 'mb-0 h4 sm:h3',
   titleButton: `${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill} sm:min-h-[44px] sm:min-w-[44px] min-h-[32px] min-w-[32px]`,
-  titleButtonLeft: '-ml-8 sm:-ml-12 absolute top-14 left-28',
-  titleButtonRight: '-mr-8 sm:-mr-12 absolute top-14 right-28',
+  titleButtonLeft: '-ml-8 sm:-ml-12 absolute top-4 left-16 sm:top-14 sm:left-28',
+  titleButtonRight: '-mr-8 sm:-mr-12 absolute top-4 right-16 sm:top-14 sm:right-28',
   titleButtonIcon: 'h-16 w-16 sm:h-24 sm:w-24',
   titleButtonIconRotated: 'transform rotate-90',
 };
@@ -555,7 +555,7 @@ export const backwardsCompatibleClasses = {
   radioInvalid: 'peer-checked:before:i-border-$color-radio-negative-border-selected peer-checked:peer-hover:before:i-border-$color-radio-negative-border-selected-hover ', //replaced in v1.5.0
   radioDisabled: 'before:i-bg-$color-radio-background-disabled before:i-bg-$color-checkbox-background-disabled peer-checked:before:i-border-$color-radio-border-selected-disabled', //replaced in v1.5.0
   modal: 'space-y-16', //removed
-  modalTitle: 'items-center', //replaced by items-start
+  modalTitle: '-mt-4 items-center', //replaced by pb-8 sm:pb-0 items-start
   titleButtonLeft: 'justify-self-start', //replaced by absolute top-14 left-28
   titleButtonRight: 'justify-self-end' //replaced by absolute top-14 right-28
 };

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -379,17 +379,17 @@ export const modal = {
   backdrop:
     'fixed inset-0 flex sm:place-content-center sm:place-items-center items-end z-30 [--w-modal-max-height:80%] [--w-modal-width:640px]',
   modal:
-    'pb-safe-[32] i-shadow-$shadow-modal max-h-[--w-modal-max-height] min-h-[--w-modal-min-height] w-[--w-modal-width] h-[--w-modal-height] relative transition-300 ease-in-out backface-hidden will-change-height rounded-8 mx-0 sm:mx-16 i-bg-$color-modal-background flex flex-col overflow-hidden outline-none space-y-16 pt-8 sm:pt-32 sm:pb-32 rounded-b-0 sm:rounded-b-8',
+    'pb-safe-[32] i-shadow-$shadow-modal max-h-[--w-modal-max-height] min-h-[--w-modal-min-height] w-[--w-modal-width] h-[--w-modal-height] relative transition-300 ease-in-out backface-hidden will-change-height rounded-8 mx-0 sm:mx-16 i-bg-$color-modal-background flex flex-col overflow-hidden outline-none pt-8 sm:pt-32 sm:pb-32 rounded-b-0 sm:rounded-b-8',
   content:
-    'block overflow-y-auto overflow-x-hidden last-child:mb-0 grow shrink px-16 sm:px-32 relative',
-  footer: 'flex justify-end shrink-0 px-16 sm:px-32',
+    'block overflow-y-auto overflow-x-hidden last-child:mb-0 grow shrink px-16 sm:px-32 sm:mt-16 relative',
+  footer: 'mt-16 flex justify-end shrink-0 px-16 sm:px-32',
   transitionTitle: 'transition-all duration-300',
   transitionTitleCenter: 'justify-self-center',
   transitionTitleColSpan: 'col-span-2',
   title:
-    '-mt-4 sm:-mt-8 h-40 sm:h-48 grid gap-8 sm:gap-16 grid-cols-[auto_1fr_auto] items-center px-16 sm:px-32 border-b sm:border-b-0 shrink-0',
+    '-mt-4 sm:-mt-8 h-40 sm:h-48 grid gap-8 sm:gap-16 grid-cols-[auto_1fr_auto] items-start px-16 sm:px-32 border-b sm:border-b-0 shrink-0',
   titleText: 'mb-0 h4 sm:h3',
-  titleButton: `${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill} sm:min-h-[44px] sm:min-w-[44px] min-h-[32px] min-w-[32px]`,
+  titleButton: `${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill} items-start! sm:min-h-[44px] sm:min-w-[44px] min-h-[32px] min-w-[32px]`,
   titleButtonLeft: '-ml-8 sm:-ml-12 justify-self-start',
   titleButtonRight: '-mr-8 sm:-mr-12 justify-self-end',
   titleButtonIcon: 'h-16 w-16 sm:h-24 sm:w-24',
@@ -553,4 +553,6 @@ export const backwardsCompatibleClasses = {
   checkboxInvalid: 'peer-checked:before:i-border-$color-checkbox-negative-border-selected peer-checked:peer-hover:before:i-border-$color-checkbox-negative-border-selected-hover', //replaced in v1.5.0
   radioInvalid: 'peer-checked:before:i-border-$color-radio-negative-border-selected peer-checked:peer-hover:before:i-border-$color-radio-negative-border-selected-hover ', //replaced in v1.5.0
   radioDisabled: 'before:i-bg-$color-radio-background-disabled before:i-bg-$color-checkbox-background-disabled peer-checked:before:i-border-$color-radio-border-selected-disabled', //replaced in v1.5.0
+  modal: 'space-y-16', //removed
+  modalTitle: 'items-center' //replaced by items-start
 };

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -386,12 +386,13 @@ export const modal = {
   transitionTitle: 'transition-all duration-300',
   transitionTitleCenter: 'justify-self-center',
   transitionTitleColSpan: 'col-span-2',
+  transitionTitleMaxWidth: 'max-w-7/8',
   title:
     '-mt-4 sm:-mt-8 h-40 sm:h-48 grid gap-8 sm:gap-16 grid-cols-[auto_1fr_auto] items-start px-16 sm:px-32 border-b sm:border-b-0 shrink-0',
   titleText: 'mb-0 h4 sm:h3',
-  titleButton: `${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill} items-start! sm:min-h-[44px] sm:min-w-[44px] min-h-[32px] min-w-[32px]`,
-  titleButtonLeft: '-ml-8 sm:-ml-12 justify-self-start',
-  titleButtonRight: '-mr-8 sm:-mr-12 justify-self-end',
+  titleButton: `${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill} sm:min-h-[44px] sm:min-w-[44px] min-h-[32px] min-w-[32px]`,
+  titleButtonLeft: '-ml-8 sm:-ml-12 absolute top-14 left-28',
+  titleButtonRight: '-mr-8 sm:-mr-12 absolute top-14 right-28',
   titleButtonIcon: 'h-16 w-16 sm:h-24 sm:w-24',
   titleButtonIconRotated: 'transform rotate-90',
 };
@@ -554,5 +555,7 @@ export const backwardsCompatibleClasses = {
   radioInvalid: 'peer-checked:before:i-border-$color-radio-negative-border-selected peer-checked:peer-hover:before:i-border-$color-radio-negative-border-selected-hover ', //replaced in v1.5.0
   radioDisabled: 'before:i-bg-$color-radio-background-disabled before:i-bg-$color-checkbox-background-disabled peer-checked:before:i-border-$color-radio-border-selected-disabled', //replaced in v1.5.0
   modal: 'space-y-16', //removed
-  modalTitle: 'items-center' //replaced by items-start
+  modalTitle: 'items-center', //replaced by items-start
+  titleButtonLeft: 'justify-self-start', //replaced by absolute top-14 left-28
+  titleButtonRight: 'justify-self-end' //replaced by absolute top-14 right-28
 };

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -388,7 +388,7 @@ export const modal = {
   transitionTitleColSpan: 'col-span-2',
   transitionTitleMaxWidth: ' max-w-6/8 md:max-w-7/8',
   title:
-    'pb-8 sm:pb-0 sm:-mt-8 h-40 sm:h-48 grid gap-8 sm:gap-16 grid-cols-[auto_1fr_auto] items-start px-16 sm:px-32 border-b sm:border-b-0 shrink-0',
+    'pb-4 sm:pb-0 sm:-mt-8 h-40 sm:h-48 grid gap-8 sm:gap-16 grid-cols-[auto_1fr_auto] items-start px-16 sm:px-32 border-b sm:border-b-0 shrink-0',
   titleText: 'mb-0 h4 sm:h3',
   titleButton: `${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill} sm:min-h-[44px] sm:min-w-[44px] min-h-[32px] min-w-[32px]`,
   titleButtonLeft: '-ml-8 sm:-ml-12 absolute top-4 left-16 sm:top-14 sm:left-28',
@@ -555,7 +555,7 @@ export const backwardsCompatibleClasses = {
   radioInvalid: 'peer-checked:before:i-border-$color-radio-negative-border-selected peer-checked:peer-hover:before:i-border-$color-radio-negative-border-selected-hover ', //replaced in v1.5.0
   radioDisabled: 'before:i-bg-$color-radio-background-disabled before:i-bg-$color-checkbox-background-disabled peer-checked:before:i-border-$color-radio-border-selected-disabled', //replaced in v1.5.0
   modal: 'space-y-16', //removed
-  modalTitle: '-mt-4 items-center', //replaced by pb-8 sm:pb-0 items-start
+  modalTitle: '-mt-4 items-center', //replaced by pb-4 sm:pb-0 items-start
   titleButtonLeft: 'justify-self-start', //replaced by absolute top-14 left-28
   titleButtonRight: 'justify-self-end' //replaced by absolute top-14 right-28
 };


### PR DESCRIPTION
These changes are part of fixes for this JIRA ticket: [WARP-429](https://nmp-jira.atlassian.net/browse/WARP-429)

**Changes:**
- Removed `space-y-16` from modal and set instead `mt-16` directly on content and footer on the modal. This was needed to remove the margin-top from the content on mobile so that the title's divider hade no space underneath it.

- Adjusted modal title and have replaced `-mt-4 `with `pb-4` + replaced `items-center` with `items-start` to align with the new styled buttons (right and left buttons). 

- Refactored `titleButtonLeft` and `titleButtonRight` to instead have an absolute position so that they will be fixed on the top left/right corners. 

- Added classes that were removed in this branch to the `backwardsCompatibleClasses` object. 

**Questions:** 
1. Not sure if `modalTitle` is correctly set in the `backwardsCompatibleClasses` object, since it is called `title` but we have several titles in component-classes with the same name. Does it matter how we name the variables in `backwardsCompatibleClasses` or is the main part that we make sure that we still create styles for the removed classes? 

2. In the linked [slack-discussion](https://sch-chat.slack.com/archives/C04P0GYTHPV/p1701177130162429) in the JIRA ticket, it was mentioned that our Vue-modal has a `headerClasses` prop, making it possible for a user to add/change styles for the modal title. It was mentioned in the discussion that this `headerClasses` prop should also be added to the React-modal. However, is there a reason why we have set the modal title's height to a fixed height of `h-40 sm:48`? Or could we replace the fixed height with instead `h-full` here in the component-classes directly, instead of the user adjusting this themselves in the `headerClasses` prop?