### PR TITLE
fix: adjust padding and height for modal title

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -491,4 +491,5 @@ export namespace backwardsCompatibleClasses {
     export { radioInvalid_1 as radioInvalid };
     const radioDisabled_1: string;
     export { radioDisabled_1 as radioDisabled };
+    export const modalTitle: string;
 }

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -387,7 +387,7 @@ export const modal = {
   transitionTitleCenter: 'justify-self-center',
   transitionTitleColSpan: 'col-span-2',
   title:
-    '-mt-4 sm:-mt-8 h-40 sm:h-48 grid gap-8 sm:gap-16 grid-cols-[auto_1fr_auto] items-center px-16 sm:px-32 border-b sm:border-b-0 shrink-0',
+    'py-8 sm:py-0 -mt-4 sm:-mt-8 min-h-40 sm:min-h-48 grid gap-8 sm:gap-16 grid-cols-[auto_1fr_auto] items-center px-16 sm:px-32 border-b sm:border-b-0 shrink-0',
   titleText: 'mb-0 h4 sm:h3',
   titleButton: `${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill} sm:min-h-[44px] sm:min-w-[44px] min-h-[32px] min-w-[32px]`,
   titleButtonLeft: '-ml-8 sm:-ml-12 justify-self-start',
@@ -553,4 +553,5 @@ export const backwardsCompatibleClasses = {
   checkboxInvalid: 'peer-checked:before:i-border-$color-checkbox-negative-border-selected peer-checked:peer-hover:before:i-border-$color-checkbox-negative-border-selected-hover', //replaced in v1.5.0
   radioInvalid: 'peer-checked:before:i-border-$color-radio-negative-border-selected peer-checked:peer-hover:before:i-border-$color-radio-negative-border-selected-hover ', //replaced in v1.5.0
   radioDisabled: 'before:i-bg-$color-radio-background-disabled before:i-bg-$color-checkbox-background-disabled peer-checked:before:i-border-$color-radio-border-selected-disabled', //replaced in v1.5.0
+  modalTitle: 'h-40 sm:h-48' // replaced by min-h-40 sm:min-h-48
 };

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -384,10 +384,10 @@ export const modal = {
     'block overflow-y-auto overflow-x-hidden last-child:mb-0 grow shrink px-16 sm:px-32 relative',
   footer: 'flex justify-end shrink-0 px-16 sm:px-32',
   transitionTitle: 'transition-all duration-300',
-  transitionTitleCenter: 'justify-self-center',
+  transitionTitleCenter: 'justify-self-center self-center',
   transitionTitleColSpan: 'col-span-2',
   title:
-    'py-8 sm:py-0 -mt-4 sm:-mt-8 min-h-40 sm:min-h-48 grid gap-8 sm:gap-16 grid-cols-[auto_1fr_auto] items-center px-16 sm:px-32 border-b sm:border-b-0 shrink-0',
+    'py-8 sm:py-0 -mt-4 sm:-mt-8 min-h-40 sm:min-h-48 grid gap-8 sm:gap-16 grid-cols-[auto_1fr_auto] items-start px-16 sm:px-32 border-b sm:border-b-0 shrink-0',
   titleText: 'mb-0 h4 sm:h3',
   titleButton: `${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill} sm:min-h-[44px] sm:min-w-[44px] min-h-[32px] min-w-[32px]`,
   titleButtonLeft: '-ml-8 sm:-ml-12 justify-self-start',
@@ -553,5 +553,5 @@ export const backwardsCompatibleClasses = {
   checkboxInvalid: 'peer-checked:before:i-border-$color-checkbox-negative-border-selected peer-checked:peer-hover:before:i-border-$color-checkbox-negative-border-selected-hover', //replaced in v1.5.0
   radioInvalid: 'peer-checked:before:i-border-$color-radio-negative-border-selected peer-checked:peer-hover:before:i-border-$color-radio-negative-border-selected-hover ', //replaced in v1.5.0
   radioDisabled: 'before:i-bg-$color-radio-background-disabled before:i-bg-$color-checkbox-background-disabled peer-checked:before:i-border-$color-radio-border-selected-disabled', //replaced in v1.5.0
-  modalTitle: 'h-40 sm:h-48' // replaced by min-h-40 sm:min-h-48
+  modalTitle: 'h-40 sm:h-48 items-center' // replaced by min-h-40 sm:min-h-48 items-start
 };


### PR DESCRIPTION
Fixes JIRA ticket: [WARP-429](https://nmp-jira.atlassian.net/browse/WARP-429)

- Replaced `h-40 sm:h-48` with `min-h-40 sm:min-h-48`
- Added `py-8` to give the `title` more space
- Replaced `items-center` with `items-start` on `title`
- Added `h-40 sm:h-48 items-center` to `backwardsCompatibleClasses`