### PR TITLE
fix: adjust pill close style

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -492,4 +492,5 @@ export namespace backwardsCompatibleClasses {
     const radioDisabled_1: string;
     export { radioDisabled_1 as radioDisabled };
     export const modalTitle: string;
+    export const pillClose: string;
 }

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -73,7 +73,7 @@ export const pill = {
   label: 'pl-12 py-8 rounded-l-full',
   labelWithoutClose: 'pr-12 rounded-r-full',
   labelWithClose: 'pr-2',
-  close: 'pr-12 pl-4 py-8 rounded-r-full',
+  close: 'pr-12 pl-4 py-10 rounded-r-full',
   a11y: 'sr-only',
 };
 
@@ -554,5 +554,5 @@ export const backwardsCompatibleClasses = {
   radioInvalid: 'peer-checked:before:i-border-$color-radio-negative-border-selected peer-checked:peer-hover:before:i-border-$color-radio-negative-border-selected-hover ', //replaced in v1.5.0
   radioDisabled: 'before:i-bg-$color-radio-background-disabled before:i-bg-$color-checkbox-background-disabled peer-checked:before:i-border-$color-radio-border-selected-disabled', //replaced in v1.5.0
   modalTitle: 'h-40 sm:h-48 items-center', // replaced by min-h-40 sm:min-h-48 items-start
-  pillClose: 'pt-4 pb-6 text-m!' //replaced by py-8
+  pillClose: 'pt-4 pb-6 text-m!' //replaced by py-10
 };

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -73,7 +73,7 @@ export const pill = {
   label: 'pl-12 py-8 rounded-l-full',
   labelWithoutClose: 'pr-12 rounded-r-full',
   labelWithClose: 'pr-2',
-  close: 'pr-12 pl-4 pt-4 pb-6 rounded-r-full text-m!',
+  close: 'pr-12 pl-4 py-8 rounded-r-full',
   a11y: 'sr-only',
 };
 
@@ -553,5 +553,6 @@ export const backwardsCompatibleClasses = {
   checkboxInvalid: 'peer-checked:before:i-border-$color-checkbox-negative-border-selected peer-checked:peer-hover:before:i-border-$color-checkbox-negative-border-selected-hover', //replaced in v1.5.0
   radioInvalid: 'peer-checked:before:i-border-$color-radio-negative-border-selected peer-checked:peer-hover:before:i-border-$color-radio-negative-border-selected-hover ', //replaced in v1.5.0
   radioDisabled: 'before:i-bg-$color-radio-background-disabled before:i-bg-$color-checkbox-background-disabled peer-checked:before:i-border-$color-radio-border-selected-disabled', //replaced in v1.5.0
-  modalTitle: 'h-40 sm:h-48 items-center' // replaced by min-h-40 sm:min-h-48 items-start
+  modalTitle: 'h-40 sm:h-48 items-center', // replaced by min-h-40 sm:min-h-48 items-start
+  pillClose: 'pt-4 pb-6 text-m!' //replaced by py-8
 };


### PR DESCRIPTION
Fixes JIRA ticket: [WARP-409](https://nmp-jira.atlassian.net/browse/WARP-409)

- Replaced `pt-4 pb-6 text-m!` with `py-10`, due to that we are replacing the letter `X` with the `IconClose16` in our Pill component.
- Updated `backwardsCompatibleClasses` to also include `pt-4 pb-6 text-m!`

**To test:**
Link this branch with the following branch in either our vue or react-repo: `fix/replace-x-with-icon`