### PR TITLE
fix: adjust padding-top and padding-bottom for pill close

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -73,7 +73,7 @@ export const pill = {
   label: 'pl-12 py-8 rounded-l-full',
   labelWithoutClose: 'pr-12 rounded-r-full',
   labelWithClose: 'pr-2',
-  close: 'pr-12 pl-4 py-10 rounded-r-full',
+  close: 'pr-12 pl-4 py-8 rounded-r-full',
   a11y: 'sr-only',
 };
 
@@ -554,7 +554,7 @@ export const backwardsCompatibleClasses = {
   radioInvalid: 'peer-checked:before:i-border-$color-radio-negative-border-selected peer-checked:peer-hover:before:i-border-$color-radio-negative-border-selected-hover ', //replaced in v1.5.0
   radioDisabled: 'before:i-bg-$color-radio-background-disabled before:i-bg-$color-checkbox-background-disabled peer-checked:before:i-border-$color-radio-border-selected-disabled', //replaced in v1.5.0
   modalTitle: 'h-40 sm:h-48 items-center', // replaced by min-h-40 sm:min-h-48 items-start
-  pillClose: 'pt-4 pb-6 text-m!' //replaced by py-10
+  pillClose: 'pt-4 pb-6 text-m!' //replaced by py-8
 };
 
 export const pagination = {


### PR DESCRIPTION
Fix related to JIRA ticket: [WARP-409](https://nmp-jira.atlassian.net/browse/WARP-409)

After being informed that the new design for pill will use an icon with size 16px, the padding-top and padding-bottom of the pill close needed to adjust its size from `py-10` to `py-8`