### PR TITLE
chore(workflows): run Lint workflow in pull requests

### DIFF
--- a/.github/workflows/lint.pr.yaml
+++ b/.github/workflows/lint.pr.yaml
@@ -1,0 +1,21 @@
+name: Lint
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install pnpm and dependencies
+      uses: pnpm/action-setup@v2
+      with:
+        version: 8
+        run_install: true
+    - name: Lint
+      run: pnpm lint:check

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build:cc": "cd component-classes && rm -rf *.d.ts && tsc && vite build",
     "build:tokens": "cd tokens && node index.js",
     "build:resets": "cd resets && node index.js",
-    "lint:fix": "eslint . --fix",
-    "lint:check": "eslint ."
+    "lint:fix": "eslint . --fix --ignore-path .gitignore",
+    "lint:check": "eslint . --ignore-path .gitignore"
   },
   "type": "module",
   "exports": {


### PR DESCRIPTION
This PR adds a Github Action workflow for checking linting errors in PRs. As a next step we could consider adding a [husky](https://typicode.github.io/husky/getting-started.html) hook for automatic lint fixing before each commit, so we always commit properly formatted changes.