### PR TITLE
fix: Deprecate redundant Breadcrumbs component tokens and classes

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -497,6 +497,7 @@ export namespace backwardsCompatibleClasses {
     export let pillClose: string;
     export let removedAlertTokens: string;
     export let removedBadgeTokens: string;
+    export let removedBreadcrumbsTokens: string;
 }
 export namespace pagination {
     export let currentPage: string;

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -435,9 +435,9 @@ export const prefix = {
 
 export const breadcrumbs = {
   wrapper: 'flex space-x-8',
-  text: 'i-text-$color-breadcrumbs-text',
-  link: 'i-text-$color-breadcrumbs-link-text',
-  separator: 'select-none i-text-$color-breadcrumbs-icon',
+  text: 's-text',
+  link: 's-text-link',
+  separator: 'select-none s-icon',
   a11y: 'sr-only',
 };
 
@@ -523,6 +523,7 @@ export const backwardsCompatibleClasses = {
   pillClose: 'pt-4 pb-6 text-m!', //replaced by py-8
   removedAlertTokens: 'i-border-$color-alert-negative-subtle-border i-bg-$color-alert-negative-background i-text-$color-alert-negative-text i-border-l-$color-alert-negative-border i-text-$color-alert-negative-icon i-border-$color-alert-positive-subtle-border i-bg-$color-alert-positive-background i-text-$color-alert-positive-text i-border-l-$color-alert-positive-border i-text-$color-alert-positive-icon i-border-$color-alert-warning-subtle-border i-bg-$color-alert-warning-background i-text-$color-alert-warning-text i-border-l-$color-alert-warning-border i-text-$color-alert-warning-icon i-border-$color-alert-info-subtle-border i-bg-$color-alert-info-background i-text-$color-alert-info-text i-border-l-$color-alert-info-border i-text-$color-alert-info-icon',
   removedBadgeTokens: 'i-bg-$color-badge-price-background i-bg-$color-badge-negative-background i-bg-$color-badge-warning-background i-bg-$color-badge-positive-background i-bg-$color-badge-info-background i-bg-$color-badge-neutral-background i-text-$color-badge-neutral-text i-text-$color-badge-negative-text i-text-$color-badge-warning-text i-text-$color-badge-positive-text i-text-$color-badge-info-text i-text-$color-badge-disabled-text i-bg-$color-badge-disabled-background i-text-$color-badge-price-text',
+  removedBreadcrumbsTokens: 'i-text-$color-breadcrumbs-text i-text-$color-breadcrumbs-link-text i-text-$color-breadcrumbs-icon',
 };
 
 export const pagination = {

--- a/tokens/blocket.se/breadcrumbs.yml
+++ b/tokens/blocket.se/breadcrumbs.yml
@@ -1,9 +1,0 @@
----
-token: maps
-
-color:
-  breadcrumbs:
-    text: s-color-text
-    link:
-      text: s-color-text-link
-    icon: s-color-icon

--- a/tokens/blocket.se/deprecated.yml
+++ b/tokens/blocket.se/deprecated.yml
@@ -70,6 +70,11 @@ color:
     notification:
       text: s-color-text-notification
       background: s-color-background-notification
+    breadcrumbs:
+      text: s-color-text
+      link:
+        text: s-color-text-link
+      icon: s-color-icon
 
 s:
   color:

--- a/tokens/finn.no/breadcrumbs.yml
+++ b/tokens/finn.no/breadcrumbs.yml
@@ -1,9 +1,0 @@
----
-token: maps
-
-color:
-  breadcrumbs:
-    text: s-color-text
-    link:
-      text: s-color-text-link
-    icon: s-color-icon

--- a/tokens/finn.no/deprecated.yml
+++ b/tokens/finn.no/deprecated.yml
@@ -70,6 +70,11 @@ color:
     notification:
       text: s-color-text-notification
       background: s-color-background-notification
+    breadcrumbs:
+      text: s-color-text
+      link:
+        text: s-color-text-link
+      icon: s-color-icon
 
 s:
   color:

--- a/tokens/tori.fi/breadcrumbs.yml
+++ b/tokens/tori.fi/breadcrumbs.yml
@@ -1,9 +1,0 @@
----
-token: maps
-
-color:
-  breadcrumbs:
-    text: s-color-text
-    link:
-      text: s-color-text-link
-    icon: s-color-icon

--- a/tokens/tori.fi/deprecated.yml
+++ b/tokens/tori.fi/deprecated.yml
@@ -70,6 +70,11 @@ color:
     notification:
       text: s-color-text-notification
       background: s-color-background-notification
+    breadcrumbs:
+      text: s-color-text
+      link:
+        text: s-color-text-link
+      icon: s-color-icon
 
 s:
   color:


### PR DESCRIPTION
- Use semantic classes (`s-text`) directly instead of component token classes (`i-text-$token`)
- Deprecate redundant component tokens and classes