### PR TITLE
fix: Deprecate redundant Button component tokens and classes

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -497,6 +497,7 @@ export namespace backwardsCompatibleClasses {
     export let pillClose: string;
     export let removedAlertTokens: string;
     export let removedBadgeTokens: string;
+    export let removedButtonTokens: string;
 }
 export namespace pagination {
     export let currentPage: string;

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -213,17 +213,17 @@ export const expandable = {
 const buttonDefaultStyling = 'font-bold focusable justify-center transition-colors ease-in-out';
 
 const buttonColors = {
-  primary: 'i-text-$color-button-primary-text hover:i-text-$color-button-primary-text i-bg-$color-button-primary-background hover:i-bg-$color-button-primary-background-hover active:i-bg-$color-button-primary-background-active',
-  secondary: 'i-text-$color-button-secondary-text hover:i-text-$color-button-secondary-text i-border-$color-button-secondary-border i-bg-$color-button-secondary-background hover:i-bg-$color-button-secondary-background-hover hover:i-border-$color-button-secondary-border-hover active:i-bg-$color-button-secondary-background-active',
-  utility: 'i-text-$color-button-utility-text hover:i-text-$color-button-utility-text i-bg-$color-button-utility-background i-border-$color-button-utility-border hover:i-bg-$color-button-utility-background hover:i-border-$color-button-utility-border-hover active:i-border-$color-button-utility-border-active',
-  destructive: 'i-bg-$color-button-negative-background i-text-$color-button-negative-text hover:i-text-$color-button-negative-text hover:i-bg-$color-button-negative-background-hover active:i-bg-$color-button-negative-background-active',
-  pill: 'i-text-$color-button-pill-icon hover:i-text-$color-button-pill-icon-hover active:i-text-$color-button-pill-icon-active i-bg-$color-button-pill-background hover:i-bg-$color-button-pill-background-hover active:i-bg-$color-button-pill-background-active',
-  disabled: 'i-text-$color-button-disabled-text i-bg-$color-button-disabled-background',
-  quiet: 'i-bg-$color-button-quiet-background i-text-$color-button-quiet-text hover:i-bg-$color-button-quiet-background-hover active:i-bg-$color-button-quiet-background-active',
-  utilityQuiet: 'i-text-$color-button-utility-quiet-text i-bg-$color-button-utility-quiet-background hover:i-bg-$color-button-utility-quiet-background-hover',
-  negativeQuiet: 'i-bg-$color-button-negative-quiet-background i-text-$color-button-negative-quiet-text hover:i-bg-$color-button-negative-quiet-background-hover active:i-bg-$color-button-negative-quiet-background-active',
-  loading: 'i-text-$color-button-loading-text i-bg-$color-button-loading-background',
-  link: 'i-text-$color-button-link-text',
+  primary: 's-text-inverted bg-[--w-color-button-primary-background] hover:bg-[--w-color-button-primary-background-hover] active:bg-[--w-color-button-primary-background-active]',
+  secondary: 's-text-link s-border s-bg hover:s-bg-hover hover:s-border-hover active:s-bg-active',
+  utility: 's-text s-bg s-border hover:s-border-hover active:s-border-active',
+  destructive: 's-bg-negative s-text-inverted hover:s-bg-negative-hover active:s-bg-negative-active',
+  pill: 's-icon hover:s-icon-hover active:s-icon-active bg-transparent hover:bg-[--w-color-button-pill-background-hover] active:bg-[--w-color-button-pill-background-active]',
+  disabled: 's-text-inverted s-bg-disabled',
+  quiet: 'bg-transparent s-text-link hover:s-bg-hover active:s-bg-active',
+  utilityQuiet: 's-text s-bg-transparent hover:s-bg-subtle-hover',
+  negativeQuiet: 's-bg s-text-negative hover:s-bg-negative-subtle-hover active:s-bg-negative-subtle-active',
+  loading: 's-text s-bg-subtle',
+  link: 's-text-link',
 };
 
 const buttonTypes = {
@@ -523,6 +523,7 @@ export const backwardsCompatibleClasses = {
   pillClose: 'pt-4 pb-6 text-m!', //replaced by py-8
   removedAlertTokens: 'i-border-$color-alert-negative-subtle-border i-bg-$color-alert-negative-background i-text-$color-alert-negative-text i-border-l-$color-alert-negative-border i-text-$color-alert-negative-icon i-border-$color-alert-positive-subtle-border i-bg-$color-alert-positive-background i-text-$color-alert-positive-text i-border-l-$color-alert-positive-border i-text-$color-alert-positive-icon i-border-$color-alert-warning-subtle-border i-bg-$color-alert-warning-background i-text-$color-alert-warning-text i-border-l-$color-alert-warning-border i-text-$color-alert-warning-icon i-border-$color-alert-info-subtle-border i-bg-$color-alert-info-background i-text-$color-alert-info-text i-border-l-$color-alert-info-border i-text-$color-alert-info-icon',
   removedBadgeTokens: 'i-bg-$color-badge-price-background i-bg-$color-badge-negative-background i-bg-$color-badge-warning-background i-bg-$color-badge-positive-background i-bg-$color-badge-info-background i-bg-$color-badge-neutral-background i-text-$color-badge-neutral-text i-text-$color-badge-negative-text i-text-$color-badge-warning-text i-text-$color-badge-positive-text i-text-$color-badge-info-text i-text-$color-badge-disabled-text i-bg-$color-badge-disabled-background i-text-$color-badge-price-text',
+  removedButtonTokens: 'hover:i-bg-$color-button-pill-background-hover active:i-bg-$color-button-pill-background-active i-bg-$color-button-primary-background hover:i-bg-$color-button-primary-background-hover active:i-bg-$color-button-primary-background-active i-text-$color-button-primary-text hover:i-text-$color-button-primary-text i-bg-$color-button-primary-background hover:i-bg-$color-button-primary-background-hover active:i-bg-$color-button-primary-background-active i-text-$color-button-secondary-text hover:i-text-$color-button-secondary-text i-border-$color-button-secondary-border i-bg-$color-button-secondary-background hover:i-bg-$color-button-secondary-background-hover hover:i-border-$color-button-secondary-border-hover active:i-bg-$color-button-secondary-background-active i-text-$color-button-utility-text hover:i-text-$color-button-utility-text i-bg-$color-button-utility-background i-border-$color-button-utility-border hover:i-bg-$color-button-utility-background hover:i-border-$color-button-utility-border-hover active:i-border-$color-button-utility-border-active i-bg-$color-button-negative-background i-text-$color-button-negative-text hover:i-text-$color-button-negative-text hover:i-bg-$color-button-negative-background-hover active:i-bg-$color-button-negative-background-active i-text-$color-button-pill-icon hover:i-text-$color-button-pill-icon-hover active:i-text-$color-button-pill-icon-active i-bg-$color-button-pill-background hover:i-bg-$color-button-pill-background-hover active:i-bg-$color-button-pill-background-active i-text-$color-button-disabled-text i-bg-$color-button-disabled-background i-bg-$color-button-quiet-background i-text-$color-button-quiet-text hover:i-bg-$color-button-quiet-background-hover active:i-bg-$color-button-quiet-background-active i-text-$color-button-utility-quiet-text i-bg-$color-button-utility-quiet-background hover:i-bg-$color-button-utility-quiet-background-hover i-bg-$color-button-negative-quiet-background i-text-$color-button-negative-quiet-text hover:i-bg-$color-button-negative-quiet-background-hover active:i-bg-$color-button-negative-quiet-background-active i-text-$color-button-loading-text i-bg-$color-button-loading-background i-text-$color-button-link-text',
 };
 
 export const pagination = {

--- a/tokens/blocket.se/buttons.yml
+++ b/tokens/blocket.se/buttons.yml
@@ -4,7 +4,6 @@ token: maps
 color:
   button:
     primary:
-      text: s-color-text-inverted
       background:
         _: s-color-background-primary
         hover: s-color-background-primary-hover
@@ -13,87 +12,7 @@ color:
         _: s-color-border-primary
         hover: s-color-border-primary-hover
         active: s-color-border-primary-active
-      icon: s-color-icon-inverted
-    secondary:
-      text: s-color-text-link
-      background:
-        _: s-color-background
-        hover: s-color-background-hover
-        active: s-color-background-active
-      border:
-        _: s-color-border
-        hover: s-color-border-hover
-        active: s-color-border-active
-      icon: s-color-icon-primary
-    quiet:
-      text: s-color-text-link
-      background:
-        _: transparent
-        hover: s-color-background-hover
-        active: s-color-background-active
-      icon: s-color-icon-primary
-    negative:
-      text: s-color-text-inverted
-      background:
-        _: s-color-background-negative
-        hover: s-color-background-negative-hover
-        active: s-color-background-negative-active
-      border:
-        _: s-color-border-negative
-        hover: s-color-border-negative-hover
-        active: s-color-border-negative-active
-      icon: s-color-icon-inverted
-      quiet:
-        text: s-color-text-negative
-        background:
-          _: transparent
-          hover: s-color-background-negative-subtle-hover
-          active: s-color-background-negative-subtle-active
-        border:
-          _: transparent
-          hover: transparent
-          active: transparent
-        icon: s-color-icon-negative
-    disabled:
-      text: s-color-text-inverted
-      background: s-color-background-disabled
-    link:
-      text: s-color-text-link
     pill:
       background:
-        _: transparent
         hover: blue-300-alpha30
         active: blue-400-alpha30
-      icon:
-        _: s-color-icon
-        hover: s-color-icon-hover
-        active: s-color-icon-active
-      overlay:
-        icon:
-          _: s-color-icon-inverted
-          hover: s-color-icon-inverted-hover
-          active: s-color-icon-inverted-active
-    loading:
-      text: s-color-text
-      background: s-color-background-subtle
-      icon: s-color-icon
-    utility:
-      text: s-color-text
-      background:
-        _: s-color-background
-        hover: s-color-background-hover
-        active: s-color-background-active
-      border:
-        _: s-color-border
-        hover: s-color-border-hover
-        active: s-color-border-active
-      quiet:
-        text: s-color-text
-        background:
-          _: transparent
-          hover: s-color-background-subtle-hover
-          active: s-color-background-subtle-active
-        border:
-          _: transparent
-          hover: transparent
-          active: transparent

--- a/tokens/blocket.se/deprecated.yml
+++ b/tokens/blocket.se/deprecated.yml
@@ -70,6 +70,91 @@ color:
     notification:
       text: s-color-text-notification
       background: s-color-background-notification
+  button:
+    primary:
+      text: s-color-text-inverted
+      icon: s-color-icon-inverted
+    secondary:
+      text: s-color-text-link
+      background:
+        _: s-color-background
+        hover: s-color-background-hover
+        active: s-color-background-active
+      border:
+        _: s-color-border
+        hover: s-color-border-hover
+        active: s-color-border-active
+      icon: s-color-icon-primary
+    quiet:
+      text: s-color-text-link
+      background:
+        _: transparent
+        hover: s-color-background-hover
+        active: s-color-background-active
+      icon: s-color-icon-primary
+    negative:
+      text: s-color-text-inverted
+      background:
+        _: s-color-background-negative
+        hover: s-color-background-negative-hover
+        active: s-color-background-negative-active
+      border:
+        _: s-color-border-negative
+        hover: s-color-border-negative-hover
+        active: s-color-border-negative-active
+      icon: s-color-icon-inverted
+      quiet:
+        text: s-color-text-negative
+        background:
+          _: transparent
+          hover: s-color-background-negative-subtle-hover
+          active: s-color-background-negative-subtle-active
+        border:
+          _: transparent
+          hover: transparent
+          active: transparent
+        icon: s-color-icon-negative
+    disabled:
+      text: s-color-text-inverted
+      background: s-color-background-disabled
+    link:
+      text: s-color-text-link
+    pill:
+      background:
+        _: transparent
+      icon:
+        _: s-color-icon
+        hover: s-color-icon-hover
+        active: s-color-icon-active
+      overlay:
+        icon:
+          _: s-color-icon-inverted
+          hover: s-color-icon-inverted-hover
+          active: s-color-icon-inverted-active
+    loading:
+      text: s-color-text
+      background: s-color-background-subtle
+      icon: s-color-icon
+    utility:
+      text: s-color-text
+      background:
+        _: s-color-background
+        hover: s-color-background-hover
+        active: s-color-background-active
+      border:
+        _: s-color-border
+        hover: s-color-border-hover
+        active: s-color-border-active
+      quiet:
+        text: s-color-text
+        background:
+          _: transparent
+          hover: s-color-background-subtle-hover
+          active: s-color-background-subtle-active
+        border:
+          _: transparent
+          hover: transparent
+          active: transparent
 
 s:
   color:

--- a/tokens/finn.no/buttons.yml
+++ b/tokens/finn.no/buttons.yml
@@ -4,7 +4,6 @@ token: maps
 color:
   button:
     primary:
-      text: s-color-text-inverted
       background:
         _: s-color-background-primary
         hover: s-color-background-primary-hover
@@ -13,87 +12,7 @@ color:
         _: s-color-border-primary
         hover: s-color-border-primary-hover
         active: s-color-border-primary-active
-      icon: s-color-icon-inverted
-    secondary:
-      text: s-color-text-link
-      background:
-        _: s-color-background
-        hover: s-color-background-hover
-        active: s-color-background-active
-      border:
-        _: s-color-border
-        hover: s-color-border-hover
-        active: s-color-border-active
-      icon: s-color-icon-primary
-    quiet:
-      text: s-color-text-link
-      background:
-        _: transparent
-        hover: s-color-background-hover
-        active: s-color-background-active
-      icon: s-color-icon-primary
-    negative:
-      text: s-color-text-inverted
-      background:
-        _: s-color-background-negative
-        hover: s-color-background-negative-hover
-        active: s-color-background-negative-active
-      border:
-        _: s-color-border-negative
-        hover: s-color-border-negative-hover
-        active: s-color-border-negative-active
-      icon: s-color-icon-inverted
-      quiet:
-        text: s-color-text-negative
-        background:
-          _: transparent
-          hover: s-color-background-negative-subtle-hover
-          active: s-color-background-negative-subtle-active
-        border:
-          _: transparent
-          hover: transparent
-          active: transparent
-        icon: s-color-icon-negative
-    disabled:
-      text: s-color-text-inverted
-      background: s-color-background-disabled
-    link:
-      text: s-color-text-link
     pill:
       background:
-        _: transparent
         hover: blue-300-alpha30
         active: blue-400-alpha30
-      icon:
-        _: s-color-icon
-        hover: s-color-icon-hover
-        active: s-color-icon-active
-      overlay:
-        icon:
-          _: s-color-icon-inverted
-          hover: s-color-icon-inverted-hover
-          active: s-color-icon-inverted-active
-    loading:
-      text: s-color-text
-      background: s-color-background-subtle
-      icon: s-color-icon
-    utility:
-      text: s-color-text
-      background:
-        _: s-color-background
-        hover: s-color-background-hover
-        active: s-color-background-active
-      border:
-        _: s-color-border
-        hover: s-color-border-hover
-        active: s-color-border-active
-      quiet:
-        text: s-color-text
-        background:
-          _: transparent
-          hover: s-color-background-subtle-hover
-          active: s-color-background-subtle-active
-        border:
-          _: transparent
-          hover: transparent
-          active: transparent

--- a/tokens/finn.no/deprecated.yml
+++ b/tokens/finn.no/deprecated.yml
@@ -70,6 +70,91 @@ color:
     notification:
       text: s-color-text-notification
       background: s-color-background-notification
+  button:
+    primary:
+      text: s-color-text-inverted
+      icon: s-color-icon-inverted
+    secondary:
+      text: s-color-text-link
+      background:
+        _: s-color-background
+        hover: s-color-background-hover
+        active: s-color-background-active
+      border:
+        _: s-color-border
+        hover: s-color-border-hover
+        active: s-color-border-active
+      icon: s-color-icon-primary
+    quiet:
+      text: s-color-text-link
+      background:
+        _: transparent
+        hover: s-color-background-hover
+        active: s-color-background-active
+      icon: s-color-icon-primary
+    negative:
+      text: s-color-text-inverted
+      background:
+        _: s-color-background-negative
+        hover: s-color-background-negative-hover
+        active: s-color-background-negative-active
+      border:
+        _: s-color-border-negative
+        hover: s-color-border-negative-hover
+        active: s-color-border-negative-active
+      icon: s-color-icon-inverted
+      quiet:
+        text: s-color-text-negative
+        background:
+          _: transparent
+          hover: s-color-background-negative-subtle-hover
+          active: s-color-background-negative-subtle-active
+        border:
+          _: transparent
+          hover: transparent
+          active: transparent
+        icon: s-color-icon-negative
+    disabled:
+      text: s-color-text-inverted
+      background: s-color-background-disabled
+    link:
+      text: s-color-text-link
+    pill:
+      background:
+        _: transparent
+      icon:
+        _: s-color-icon
+        hover: s-color-icon-hover
+        active: s-color-icon-active
+      overlay:
+        icon:
+          _: s-color-icon-inverted
+          hover: s-color-icon-inverted-hover
+          active: s-color-icon-inverted-active
+    loading:
+      text: s-color-text
+      background: s-color-background-subtle
+      icon: s-color-icon
+    utility:
+      text: s-color-text
+      background:
+        _: s-color-background
+        hover: s-color-background-hover
+        active: s-color-background-active
+      border:
+        _: s-color-border
+        hover: s-color-border-hover
+        active: s-color-border-active
+      quiet:
+        text: s-color-text
+        background:
+          _: transparent
+          hover: s-color-background-subtle-hover
+          active: s-color-background-subtle-active
+        border:
+          _: transparent
+          hover: transparent
+          active: transparent
 
 s:
   color:

--- a/tokens/tori.fi/buttons.yml
+++ b/tokens/tori.fi/buttons.yml
@@ -4,7 +4,6 @@ token: maps
 color:
   button:
     primary:
-      text: s-color-text-inverted
       background:
         _: watermelon-600
         hover: watermelon-700
@@ -13,87 +12,7 @@ color:
         _: watermelon-600
         hover: watermelon-700
         active: watermelon-800
-      icon: s-color-icon-inverted
-    secondary:
-      text: s-color-text-link
-      background:
-        _: s-color-background
-        hover: s-color-background-hover
-        active: s-color-background-active
-      border:
-        _: s-color-border
-        hover: s-color-border-hover
-        active: s-color-border-active
-      icon: s-color-icon-primary
-    quiet:
-      text: s-color-text-link
-      background:
-        _: transparent
-        hover: s-color-background-hover
-        active: s-color-background-active
-      icon: s-color-icon-primary
-    negative:
-      text: s-color-text-inverted
-      background:
-        _: s-color-background-negative
-        hover: s-color-background-negative-hover
-        active: s-color-background-negative-active
-      border:
-        _: s-color-border-negative
-        hover: s-color-border-negative-hover
-        active: s-color-border-negative-active
-      icon: s-color-icon-inverted
-      quiet:
-        text: s-color-text-negative
-        background:
-          _: transparent
-          hover: s-color-background-negative-subtle-hover
-          active: s-color-background-negative-subtle-active
-        border:
-          _: transparent
-          hover: transparent
-          active: transparent
-        icon: s-color-icon-negative
-    disabled:
-      text: s-color-text-inverted
-      background: s-color-background-disabled
-    link:
-      text: s-color-text-link
     pill:
       background:
-        _: transparent
         hover: gray-300-alpha30
         active: gray-400-alpha30
-      icon:
-        _: s-color-icon
-        hover: s-color-icon-hover
-        active: s-color-icon-active
-      overlay:
-        icon:
-          _: s-color-icon-inverted
-          hover: s-color-icon-inverted-hover
-          active: s-color-icon-inverted-active
-    loading:
-      text: s-color-text
-      background: s-color-background-subtle
-      icon: s-color-icon
-    utility:
-      text: s-color-text
-      background:
-        _: s-color-background
-        hover: s-color-background-hover
-        active: s-color-background-active
-      border:
-        _: s-color-border
-        hover: s-color-border-hover
-        active: s-color-border-active
-      quiet:
-        text: s-color-text
-        background:
-          _: transparent
-          hover: s-color-background-subtle-hover
-          active: s-color-background-subtle-active
-        border:
-          _: transparent
-          hover: transparent
-          active: transparent

--- a/tokens/tori.fi/deprecated.yml
+++ b/tokens/tori.fi/deprecated.yml
@@ -70,6 +70,91 @@ color:
     notification:
       text: s-color-text-notification
       background: s-color-background-notification
+  button:
+    primary:
+      text: s-color-text-inverted
+      icon: s-color-icon-inverted
+    secondary:
+      text: s-color-text-link
+      background:
+        _: s-color-background
+        hover: s-color-background-hover
+        active: s-color-background-active
+      border:
+        _: s-color-border
+        hover: s-color-border-hover
+        active: s-color-border-active
+      icon: s-color-icon-primary
+    quiet:
+      text: s-color-text-link
+      background:
+        _: transparent
+        hover: s-color-background-hover
+        active: s-color-background-active
+      icon: s-color-icon-primary
+    negative:
+      text: s-color-text-inverted
+      background:
+        _: s-color-background-negative
+        hover: s-color-background-negative-hover
+        active: s-color-background-negative-active
+      border:
+        _: s-color-border-negative
+        hover: s-color-border-negative-hover
+        active: s-color-border-negative-active
+      icon: s-color-icon-inverted
+      quiet:
+        text: s-color-text-negative
+        background:
+          _: transparent
+          hover: s-color-background-negative-subtle-hover
+          active: s-color-background-negative-subtle-active
+        border:
+          _: transparent
+          hover: transparent
+          active: transparent
+        icon: s-color-icon-negative
+    disabled:
+      text: s-color-text-inverted
+      background: s-color-background-disabled
+    link:
+      text: s-color-text-link
+    pill:
+      background:
+        _: transparent
+      icon:
+        _: s-color-icon
+        hover: s-color-icon-hover
+        active: s-color-icon-active
+      overlay:
+        icon:
+          _: s-color-icon-inverted
+          hover: s-color-icon-inverted-hover
+          active: s-color-icon-inverted-active
+    loading:
+      text: s-color-text
+      background: s-color-background-subtle
+      icon: s-color-icon
+    utility:
+      text: s-color-text
+      background:
+        _: s-color-background
+        hover: s-color-background-hover
+        active: s-color-background-active
+      border:
+        _: s-color-border
+        hover: s-color-border-hover
+        active: s-color-border-active
+      quiet:
+        text: s-color-text
+        background:
+          _: transparent
+          hover: s-color-background-subtle-hover
+          active: s-color-background-subtle-active
+        border:
+          _: transparent
+          hover: transparent
+          active: transparent
 
 s:
   color:


### PR DESCRIPTION
- Use semantic classes (`s-bg`) directly instead of component token classes (`i-bg-$token`) where possible
- Use arbitrary classes (`bg-[--w-token]`) instead of internal classes (`i-bg-$token`)
- Deprecate redundant component tokens and classes
