### PR TITLE
fix: Fix transparent background for readonly textfields

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -387,7 +387,7 @@ export const input = {
   textArea: 'min-h-[42] sm:min-h-[45]',
   disabled: 's-bg-disabled-subtle s-border-disabled hover:s-border-disabled! s-text-disabled pointer-events-none',
   invalid: 's-border-negative s-text-negative!',
-  readOnly: 'pl-0 bg-transparent border-0 pointer-events-none s-text',
+  readOnly: 'pl-0 bg-transparent! border-0! pointer-events-none',
   placeholder: 'placeholder:s-text-placeholder',
   wrapper: 'relative',
   suffix: 'pr-40',


### PR DESCRIPTION
Added important to bg-transparent to override the default s-bg.
Added important to border-0 as a precaution, since it is only luck that it overrides the default border-1 now.
Removed s-text as that is already added through default.

Solves: https://nmp-jira.atlassian.net/browse/WARP-507 ( https://sch-chat.slack.com/archives/C04P0GYTHPV/p1708939611865719 )
