### PR TITLE
fix(cc): fix label and helpText colors

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -370,11 +370,14 @@ export namespace label {
     let label_2: string;
     export { label_2 as label };
     export let optional: string;
+    export let labelInvalid: string;
 }
 export namespace helpText {
     let helpText: string;
     let helpTextColor: string;
     let helpTextColorInvalid: string;
+    let helpTextValid: string;
+    let helpTextInvalid: string;
 }
 export namespace suffix {
     let wrapper_7: string;

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -369,7 +369,6 @@ export namespace select {
 export namespace label {
     let label_2: string;
     export { label_2 as label };
-    export let labelInvalid: string;
     export let optional: string;
 }
 export namespace helpText {

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -374,8 +374,8 @@ export namespace label {
 }
 export namespace helpText {
     let helpText: string;
-    let helpTextValid: string;
-    let helpTextInvalid: string;
+    let helpTextColor: string;
+    let helpTextColorInvalid: string;
 }
 export namespace suffix {
     let wrapper_7: string;

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -407,8 +407,7 @@ export const select = {
 
 export const label = {
   label: 'antialiased block relative text-s font-bold pb-4 cursor-pointer s-text',
-  labelInvalid: 's-text-negative',
-  optional: 'pl-8 font-normal text-s s-text',
+  optional: 'pl-8 font-normal text-s s-text-subtle',
 };
 
 export const helpText = {

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -408,12 +408,16 @@ export const select = {
 export const label = {
   label: 'antialiased block relative text-s font-bold pb-4 cursor-pointer s-text',
   optional: 'pl-8 font-normal text-s s-text-subtle',
+  labelInvalid: 's-text-negative', // TODO: Remove in v2 - kept for backwards compatibility
 };
 
 export const helpText = {
   helpText: 'text-xs mt-4 block',
   helpTextColor: 's-text-subtle',
   helpTextColorInvalid: 's-text-negative',
+  // TODO: Remove below properties in v2 - kept for backwards compatibility
+  helpTextValid: 's-text-positive',
+  helpTextInvalid: 's-text-negative',
 };
 
 const prefixSuffixWrapperBase = 'absolute top-0 bottom-0 flex justify-center items-center focusable focus:[--w-outline-offset:-2px] bg-transparent ';

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -412,9 +412,9 @@ export const label = {
 };
 
 export const helpText = {
-  helpText: 'text-xs mt-4 block s-text-subtle',
-  helpTextValid: 's-text-positive',
-  helpTextInvalid: 's-text-negative',
+  helpText: 'text-xs mt-4 block',
+  helpTextColor: 's-text-subtle',
+  helpTextColorInvalid: 's-text-negative',
 };
 
 const prefixSuffixWrapperBase = 'absolute top-0 bottom-0 flex justify-center items-center focusable focus:[--w-outline-offset:-2px] bg-transparent ';


### PR DESCRIPTION
## Description
Fixes [WARP-515](https://nmp-jira.atlassian.net/browse/WARP-515)

Changes based on the [Figma component library](https://www.figma.com/file/oHBCzDdJxHQ6fmFLYWUltf/Warp---Components-2.0?type=design&node-id=954-37013&mode=design&t=NPcTtpnw8dXLMG36-0):
- label color doesn't change when input is invalid
- label optional should have subtle text color (the other changes to label optional should be handled in a separate task)
- helpText color should be negative when input is invalid
- there is no use for positive helpText, so it was removed

<img width="164" alt="Screenshot of Radio group component with label in dark grey and help text in red" src="https://github.com/warp-ds/css/assets/41303231/8e721ee5-0a9c-4d81-af23-78fad752eb07">
<img width="240" alt="Screenshot of TextField component with label in dark grey and help text in red" src="https://github.com/warp-ds/css/assets/41303231/535a6a2f-e4ce-4299-9e08-c5710b78b83f">
<img width="240" alt="Screenshot of Textarea component with label in dark grey and help text in red" src="https://github.com/warp-ds/css/assets/41303231/7ce0b9bd-1b8b-42bc-9d9f-9f19b27bc4bd">
<img width="245" alt="Screenshot of Selecta component with label in dark grey and help text in red" src="https://github.com/warp-ds/css/assets/41303231/3f9ad6e7-55be-48bd-acda-b87cbf8174d9">
<img width="242" alt="Screenshot of Select component with optional label in subtle grey" src="https://github.com/warp-ds/css/assets/41303231/524068df-b3f9-4de8-837c-cc6c6fd3be5e">
