### PR TITLE
fix(cc-input/select): fix outline color in invalid state

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -397,7 +397,7 @@ export const input = {
 export const select = {
   default: 'block text-m mb-0 leading-m s-text s-bg s-border hover:s-border-hover active:s-border-active rounded-4 py-12 px-8 block border-1 w-full focusable focus:[--w-outline-offset:-2px] appearance-none pr-32 cursor-pointer caret-current',
   disabled: 's-bg-disabled-subtle s-border-disabled hover:s-border-disabled! active:s-border-disabled! s-text-disabled pointer-events-none',
-  invalid: 's-border-negative',
+  invalid: 's-border-negative hover:s-border-negative-hover! outline-[--w-s-color-border-negative]!',
   readOnly: 'pl-0 bg-transparent border-0 pointer-events-none before:hidden',
   wrapper: 'relative',
   selectWrapper: `relative before:block before:absolute before:right-0 before:bottom-0 before:w-32 before:h-full before:pointer-events-none `,

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -417,7 +417,7 @@ export const helpText = {
   helpTextInvalid: 's-text-negative',
 };
 
-const prefixSuffixWrapperBase = 'absolute top-0 bottom-0 flex justify-center items-center focusable focus:[--w-outline-offset:-2px] bg-transparent ';
+const prefixSuffixWrapperBase = 'absolute top-0 bottom-0 flex justify-center items-center focusable rounded-4 focus:[--w-outline-offset:-2px] bg-transparent ';
 
 export const suffix = {
   wrapper: prefixSuffixWrapperBase + 'right-0',

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -386,7 +386,7 @@ export const input = {
   default: 'block text-m mb-0 leading-m s-text s-bg s-border hover:s-border-hover active:s-border-selected rounded-4 py-12 px-8 block border-1 w-full focusable focus:[--w-outline-offset:-2px] caret-current',
   textArea: 'min-h-[42] sm:min-h-[45]',
   disabled: 's-bg-disabled-subtle s-border-disabled hover:s-border-disabled! s-text-disabled pointer-events-none',
-  invalid: 's-border-negative s-text-negative!',
+  invalid: 's-border-negative s-text-negative! hover:s-border-negative-hover! outline-[--w-s-color-border-negative]!',
   readOnly: 'pl-0 bg-transparent! border-0! pointer-events-none',
   placeholder: 'placeholder:s-text-placeholder',
   wrapper: 'relative',


### PR DESCRIPTION
## Description
Fixes [WARP-340](https://nmp-jira.atlassian.net/browse/WARP-340)

Changes based on the [Figma component library](https://www.figma.com/file/oHBCzDdJxHQ6fmFLYWUltf/Warp---Components-2.0?type=design&node-id=381-40600&mode=design&t=3zNbTFLWoztqzMDE-0):
- outline color is set to s-border-negative when `input` or `select` element is in invalid state

<img width="302" alt="Screenshot of focused Textarea component in invalid state" src="https://github.com/warp-ds/css/assets/41303231/18128386-ed73-4f5e-8887-9b9ee4cb5c19">
<img width="286" alt="Screenshot of focused Select component in invalid state" src="https://github.com/warp-ds/css/assets/41303231/a7be6bff-3e31-419a-bd93-515f29897ef3">

- border color is set to s-border-negative-hover when invalid `input` or `select` element is hovered

<img width="285" alt="Screenshot of invalid Select component in hover state" src="https://github.com/warp-ds/css/assets/41303231/fecd8922-7a11-4a3e-a7ae-f361c6727cb1">

- additionally, border-radius was set to 4px for prefix/suffix elements to make their focus outline align with input outline.

<img width="214" alt="Screenshot of focused suffix element in TextField component" src="https://github.com/warp-ds/css/assets/41303231/b9ce8a38-411e-485e-9a61-140f774bec02">
<img width="216" alt="Screenshot of focused prefix element in TextField component" src="https://github.com/warp-ds/css/assets/41303231/aff7a949-3e4f-41b0-909b-ff05fc8ff99c">


