### PR TITLE
fix: Hovered links should have underline, for all brands, through the resets css

### DIFF
--- a/resets/resets.js
+++ b/resets/resets.js
@@ -105,7 +105,7 @@ a {
 a:hover,
 a:focus,
 a:active {
-  text-decoration: var(--w-decoration-text-link);
+  text-decoration: underline;
 }
 
 /*

--- a/tokens/blocket.se/base.yml
+++ b/tokens/blocket.se/base.yml
@@ -29,7 +29,3 @@ line:
     xl: 3.4rem
     xxl: 4.1rem
     xxxl: 5.6rem
-
-decoration:
-  text:
-    link: underline

--- a/tokens/blocket.se/deprecated-defs.yml
+++ b/tokens/blocket.se/deprecated-defs.yml
@@ -28,3 +28,7 @@ bluegray:
   700: "#3B4353"
   800: "#292d38"
   900: "#181a1f"
+
+decoration:
+  text:
+    link: underline

--- a/tokens/finn.no/base.yml
+++ b/tokens/finn.no/base.yml
@@ -29,7 +29,3 @@ line:
     xl: 3.4rem
     xxl: 4.1rem
     xxxl: 5.6rem
-
-decoration:
-  text:
-    link: underline

--- a/tokens/finn.no/deprecated-defs.yml
+++ b/tokens/finn.no/deprecated-defs.yml
@@ -28,3 +28,7 @@ bluegray:
   700: "#3B4353"
   800: "#292d38"
   900: "#181a1f"
+
+decoration:
+  text:
+    link: underline

--- a/tokens/tori.fi/base.yml
+++ b/tokens/tori.fi/base.yml
@@ -29,7 +29,3 @@ line:
     xl: 3.4rem
     xxl: 4.1rem
     xxxl: 5.6rem
-
-decoration:
-  text:
-    link: none

--- a/tokens/tori.fi/deprecated-defs.yml
+++ b/tokens/tori.fi/deprecated-defs.yml
@@ -30,3 +30,7 @@ petroleum:
   700: "#1B5E6A"
   800: "#193F47"
   900: "#122226"
+
+decoration:
+  text:
+    link: underline


### PR DESCRIPTION
Deprecate decoration-text-link token and make hovered links have underline, for all brands, through the resets css.

https://nmp-jira.atlassian.net/browse/WARP-508
