### PR TITLE
fix: New semantic icon colors for hover and active states in Tori

### DIFF
--- a/tokens/tori.fi/semantic.yml
+++ b/tokens/tori.fi/semantic.yml
@@ -126,8 +126,8 @@ s:
     icon:
       _: gray-900
       static: gray-900
-      hover: gray-900
-      active: gray-900
+      hover: blueberry-800
+      active: blueberry-900
       selected:
         _: blueberry-600
         hover: blueberry-700


### PR DESCRIPTION
![image](https://github.com/warp-ds/css/assets/7531505/9b154661-49fb-4228-863c-3edee9d6def9)
