### PR TITLE
fix: Add svg icon tokens for list-checked

### DIFF
--- a/tokens/blocket.se/icons.yml
+++ b/tokens/blocket.se/icons.yml
@@ -1,8 +1,12 @@
 ---
 token: defs
 
+icon:
+  # Used for list-checked, hard coded stroke color value set to the equivalent of s-color-icon-selected (as it is not possible to have css vars as values in background images)
+  list:
+    check: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3E%3Ctitle%3ECheckmark%3C/title%3E%3Cpath stroke='%230063fb' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M3.83 7.667 7.163 11l5.334-6'%3E%3C/path%3E%3C/svg%3E");
+
 # TODO This is not the way to go but it is a shortcut made to be able to add a check mark icon to the toggle. Toggle component needs to be refactored to inline the icon or handled in another way
 form:
   check:
     mark: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e")
-

--- a/tokens/finn.no/icons.yml
+++ b/tokens/finn.no/icons.yml
@@ -1,6 +1,11 @@
 ---
 token: defs
 
+icon:
+  # Used for list-checked, hard coded stroke color value set to the equivalent of s-color-icon-selected (as it is not possible to have css vars as values in background images)
+  list:
+    check: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3E%3Ctitle%3ECheckmark%3C/title%3E%3Cpath stroke='%230063fb' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M3.83 7.667 7.163 11l5.334-6'%3E%3C/path%3E%3C/svg%3E");
+
 # TODO This is not the way to go but it is a shortcut made to be able to add a check mark icon to the toggle. Toggle component needs to be refactored to inline the icon or handled in another way
 form:
   check:

--- a/tokens/tori.fi/icons.yml
+++ b/tokens/tori.fi/icons.yml
@@ -1,6 +1,11 @@
 ---
 token: defs
 
+icon:
+  # Used for list-checked, hard coded stroke color value set to the equivalent of s-color-icon-selected (as it is not possible to have css vars as values in background images)
+  list:
+    checked: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3E%3Ctitle%3ECheckmark%3C/title%3E%3Cpath stroke='%23296dcc' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M3.83 7.667 7.163 11l5.334-6'%3E%3C/path%3E%3C/svg%3E");
+
 # TODO This is not the way to go but it is a shortcut made to be able to add a check mark icon to the toggle. Toggle component needs to be refactored to inline the icon or handled in another way
 form:
   check:


### PR DESCRIPTION

![image](https://github.com/warp-ds/css/assets/7531505/d786d19b-70b2-49d4-a5d2-376f0633ef72)

Used here: https://github.com/warp-ds/drive/pull/215