### PR TITLE
fix(tabs): clean up classes

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -166,14 +166,13 @@ export namespace tabs {
 }
 export namespace tab {
     export let tab: string;
+    export let tabInactive: string;
     export let tabActive: string;
     let icon_1: string;
     export { icon_1 as icon };
-    export let iconUnderlinedActive: string;
     let content_3: string;
     export { content_3 as content };
     export let contentUnderlined: string;
-    export let contentUnderlinedActive: string;
 }
 export namespace gridLayout {
     let cols1: string;

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -513,6 +513,7 @@ export namespace backwardsCompatibleClasses {
     export let toggleIndeterminate: string;
     let input_2: string;
     export { input_2 as input };
+    export let tabs: string;
     export let removedAlertTokens: string;
     export let removedBadgeTokens: string;
     export let removedBoxTokens: string;

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -162,13 +162,12 @@ export const tabs = {
 };
 
 export const tab = {
-  tab: 'grid items-center font-bold gap-8 focusable antialias p-16 pb-8 border-b-4 bg-transparent s-text-subtle border-transparent hover:s-text-link hover:s-border-primary',
+  tab: 'grid items-center font-bold gap-8 focusable antialias p-16 pb-8 border-b-4 bg-transparent border-transparent hover:s-text-link hover:s-border-primary',
+  tabInactive: 's-text-subtle',
   tabActive: 's-text-link',
-  icon: 'mx-auto hover:s-text-link',
-  iconUnderlinedActive: 's-text-link',
+  icon: 'mx-auto',
   content: 'flex items-center justify-center gap-8',
   contentUnderlined: 'content-underlined', // content-underlined is a no-op that prevents a quirk in how Vue handles class bindings
-  contentUnderlinedActive: 's-text-link',
 };
 
 // Todo: Handle dynamic classnames

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -156,9 +156,9 @@ export const toast = {
 };
 
 export const tabs = {
-  tabContainer: 'inline-grid relative',
+  tabContainer: 'inline-grid relative -mb-1',
   wunderbar: 'absolute s-border-selected -bottom-0 border-b-4 transition-all',
-  wrapperUnderlined: 'border-b border-transparent -mx-16 sm:mx-0 px-4 sm:px-0 mb-32 ',
+  wrapperUnderlined: 'inline-block border-b s-border mb-32',
 };
 
 export const tab = {
@@ -547,6 +547,7 @@ export const backwardsCompatibleClasses = {
   radioButton: 'flex! py-[5px]! px-[8px]!',
   toggleIndeterminate: 'before:content-["-"] before:flex! before:items-center before:justify-center peer-indeterminate:hover:before:s-border-primary',
   input: 'hover:s-border-disabled! s-text-negative! hover:s-border-negative-hover! bg-transparent! border-0! pl-40',
+  tabs: 'px-4 sm:px-0',
   removedAlertTokens: 'i-border-$color-alert-negative-subtle-border i-bg-$color-alert-negative-background i-text-$color-alert-negative-text i-border-l-$color-alert-negative-border i-text-$color-alert-negative-icon i-border-$color-alert-positive-subtle-border i-bg-$color-alert-positive-background i-text-$color-alert-positive-text i-border-l-$color-alert-positive-border i-text-$color-alert-positive-icon i-border-$color-alert-warning-subtle-border i-bg-$color-alert-warning-background i-text-$color-alert-warning-text i-border-l-$color-alert-warning-border i-text-$color-alert-warning-icon i-border-$color-alert-info-subtle-border i-bg-$color-alert-info-background i-text-$color-alert-info-text i-border-l-$color-alert-info-border i-text-$color-alert-info-icon',
   removedBadgeTokens: 'i-bg-$color-badge-price-background i-bg-$color-badge-negative-background i-bg-$color-badge-warning-background i-bg-$color-badge-positive-background i-bg-$color-badge-info-background i-bg-$color-badge-neutral-background i-text-$color-badge-neutral-text i-text-$color-badge-negative-text i-text-$color-badge-warning-text i-text-$color-badge-positive-text i-text-$color-badge-info-text i-text-$color-badge-disabled-text i-bg-$color-badge-disabled-background i-text-$color-badge-price-text',
   removedBoxTokens: 'i-bg-$color-box-info-background i-text-$color-box-info-text i-bg-$color-box-neutral-background i-text-$color-box-neutral-text i-border-$color-box-bordered-border i-bg-$color-box-bordered-background i-text-$color-box-bordered-text hover:i-bg-$color-box-info-background-hover active:i-bg-$color-box-info-background-hover hover:i-bg-$color-box-neutral-background-hover active:i-bg-$color-box-neutral-background-hover hover:i-bg-$color-box-bordered-background-hover active:i-bg-$color-box-bordered-background-hover hover:i-border-$color-box-bordered-border-hover active:i-border-$color-box-bordered-border-hover',


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the Tabs component.
Additionally, this PR fixes [WARP-488](https://nmp-jira.atlassian.net/browse/WARP-488) by restoring a bottom border of subtle gray for the whole Tabs wrapper.

## Testing
Tested the changes in @warp-ds/react and @warp-ds/vue (`203-fixtabs-clean-up-classes` branch)

React:
![gif showing navigation and correct state colors in React Tabs component](https://github.com/warp-ds/css/assets/41303231/f2ce7679-f9ad-4782-add0-4fe900317e1e)

Vue:
<img width="264" alt="Screenshot of a Vue Tabs component with 3 tabs, the first one in active state" src="https://github.com/warp-ds/css/assets/41303231/40ed2277-cea9-41d2-8641-ce39f0c2012e">
