### PR TITLE
chore: update pnpm to v9

### DIFF
--- a/.github/workflows/lint.pr.yaml
+++ b/.github/workflows/lint.pr.yaml
@@ -15,6 +15,7 @@ jobs:
     - name: Install pnpm and dependencies
       uses: pnpm/action-setup@v2
       with:
+        version: 9
         run_install: true
     - name: Lint
       run: pnpm lint:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
           node-version: lts/*
       - uses: pnpm/action-setup@v2
         with:
+          version: 9
           run_install: true
       - name: Build
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -79,6 +79,5 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
-  "license": "Apache-2.0",
-  "packageManager": "pnpm@9.0.6"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
After having an internal discussion we agreed that we should update the `pnpm` version the github action runner will install to v9, and remove the `"packageManager": "pnpm@9.0.6"`  from `package.json`. All contributors will need to update `pnpm` to v9 with `pnpm add -g pnpm` in order to align with the lockfile versions. We've chosen this path with a hope that there will be no more actions required for a long period of time, i.e. until a new major version of `pnpm` creates a breaking change in the lockfiles, which could cause the CI jobs to fail. If we experience that this sort of maintenance is not working too well over time and we see no better way to solve it, we agreed to reconsider the use of [asdf](https://asdf-vm.com/) or [direnv](https://direnv.net/) in order to align the version of `pnpm` and `node` among Warp contributors.