### PR TITLE
fix: clean up step and steps classes

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -52,27 +52,28 @@ export namespace pill {
     let a11y: string;
 }
 export namespace step {
-    let step: string;
-    let vertical: string;
-    let horizontal: string;
-    let alignLeft: string;
-    let alignRight: string;
-    let stepDot: string;
-    let dotAlignRight: string;
-    let dotHorizontal: string;
-    let dotActive: string;
-    let dotIncomplete: string;
-    let stepLine: string;
-    let lineVertical: string;
-    let lineAlignRight: string;
-    let lineHorizontal: string;
-    let lineHorizontalAlignRight: string;
-    let lineHorizontalAlignLeft: string;
-    let lineIncomplete: string;
-    let lineComplete: string;
-    let content: string;
-    let contentVertical: string;
-    let contentHorizontal: string;
+    export let step: string;
+    export let vertical: string;
+    export let horizontal: string;
+    export let alignLeft: string;
+    export let alignRight: string;
+    let dot_1: string;
+    export { dot_1 as dot };
+    export let dotAlignRight: string;
+    export let dotHorizontal: string;
+    export let dotActive: string;
+    export let dotIncomplete: string;
+    export let line: string;
+    export let lineVertical: string;
+    export let lineAlignRight: string;
+    export let lineHorizontal: string;
+    export let lineHorizontalAlignRight: string;
+    export let lineHorizontalAlignLeft: string;
+    export let lineIncomplete: string;
+    export let lineComplete: string;
+    export let content: string;
+    export let contentVertical: string;
+    export let contentHorizontal: string;
 }
 export namespace steps {
     export let container: string;

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -53,30 +53,31 @@ export namespace pill {
 }
 export namespace step {
     let step: string;
-    let stepVertical: string;
-    let stepVerticalLeft: string;
-    let stepVerticalRight: string;
-    let stepHorizontal: string;
+    let vertical: string;
+    let horizontal: string;
+    let alignLeft: string;
+    let alignRight: string;
     let stepDot: string;
-    let stepDotVerticalRight: string;
-    let stepDotHorizontal: string;
-    let stepDotActive: string;
-    let stepDotIncomplete: string;
+    let dotAlignRight: string;
+    let dotHorizontal: string;
+    let dotActive: string;
+    let dotIncomplete: string;
     let stepLine: string;
-    let stepLineVertical: string;
-    let stepLineVerticalRight: string;
-    let stepLineHorizontal: string;
-    let stepLineHorizontalRight: string;
-    let stepLineHorizontalLeft: string;
-    let stepLineIncomplete: string;
-    let stepLineComplete: string;
+    let lineVertical: string;
+    let lineAlignRight: string;
+    let lineHorizontal: string;
+    let lineHorizontalAlignRight: string;
+    let lineHorizontalAlignLeft: string;
+    let lineIncomplete: string;
+    let lineComplete: string;
     let content: string;
     let contentVertical: string;
     let contentHorizontal: string;
 }
 export namespace steps {
-    let steps: string;
-    let stepsHorizontal: string;
+    export let container: string;
+    let horizontal_1: string;
+    export { horizontal_1 as horizontal };
 }
 export namespace card {
     export let card: string;
@@ -109,7 +110,8 @@ export namespace switchToggle {
     export { a11y_2 as a11y };
 }
 export namespace toaster {
-    export let container: string;
+    let container_1: string;
+    export { container_1 as container };
     let content_1: string;
     export { content_1 as content };
     export let toaster: string;
@@ -255,7 +257,8 @@ export namespace buttonGroup {
     let wrapper_3: string;
     export { wrapper_3 as wrapper };
     export let raised: string;
-    export let vertical: string;
+    let vertical_1: string;
+    export { vertical_1 as vertical };
     export let nonOutlinedVertical: string;
     export let nonOutlinedHorizontal: string;
 }

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -52,7 +52,7 @@ export namespace pill {
     let a11y: string;
 }
 export namespace step {
-    export let step: string;
+    export let container: string;
     export let vertical: string;
     export let horizontal: string;
     export let alignLeft: string;
@@ -76,7 +76,8 @@ export namespace step {
     export let contentHorizontal: string;
 }
 export namespace steps {
-    export let container: string;
+    let container_1: string;
+    export { container_1 as container };
     let horizontal_1: string;
     export { horizontal_1 as horizontal };
 }
@@ -111,8 +112,8 @@ export namespace switchToggle {
     export { a11y_2 as a11y };
 }
 export namespace toaster {
-    let container_1: string;
-    export { container_1 as container };
+    let container_2: string;
+    export { container_2 as container };
     let content_1: string;
     export { content_1 as content };
     export let toaster: string;

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -57,26 +57,27 @@ export const pill = {
 
 export const step = {
   step: 'group/step',
-  stepVertical: 'group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16',
-  stepVerticalLeft: 'grid-cols-[20px_1fr]',
-  stepVerticalRight: 'grid-cols-[1fr_20px] text-right',
-  stepHorizontal: 'group/steph grid-rows-[auto_20px] grid-cols-[1fr_20px_1fr] flex-1 grid gap-y-16 items-center',
+  vertical: 'group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16',
+  horizontal: 'group/steph grid-rows-[auto_20px] grid-cols-[1fr_20px_1fr] flex-1 grid gap-y-16 items-center',
+
+  alignLeft: 'grid-cols-[20px_1fr]',
+  alignRight: 'grid-cols-[1fr_20px] text-right',
 
   stepDot: 'rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted',
-  stepDotVerticalRight: 'col-start-2',
-  stepDotHorizontal: 'row-start-2 justify-self-end',
-  stepDotActive: 's-border-primary s-bg-primary',
-  stepDotIncomplete: 's-border s-bg',
+  dotAlignRight: 'col-start-2',
+  dotHorizontal: 'row-start-2 justify-self-end',
+  dotActive: 's-border-primary s-bg-primary',
+  dotIncomplete: 's-border s-bg',
 
   stepLine: 'group-last/stepv:hidden transition-colors duration-300',
-  stepLineVertical: 'w-2 h-full justify-self-center',
-  stepLineVerticalRight: 'col-start-2',
-  stepLineHorizontal: 'h-2 w-full row-start-2',
-  stepLineHorizontalRight: 'group-last/steph:bg-transparent',
-  stepLineHorizontalLeft: 'group-first/steph:bg-transparent',
+  lineVertical: 'w-2 h-full justify-self-center',
+  lineAlignRight: 'col-start-2',
+  lineHorizontal: 'h-2 w-full row-start-2',
+  lineHorizontalAlignRight: 'group-last/steph:bg-transparent',
+  lineHorizontalAlignLeft: 'group-first/steph:bg-transparent',
 
-  stepLineIncomplete: 's-bg-disabled',
-  stepLineComplete: 's-bg-primary',
+  lineIncomplete: 's-bg-disabled',
+  lineComplete: 's-bg-primary',
 
   content: 'last:mb-0 group-last/step:last:pb-0',
   contentVertical: 'row-span-2 pb-32',
@@ -84,9 +85,10 @@ export const step = {
 };
 
 export const steps = {
-  steps: 'w-full',
-  stepsHorizontal: 'flex',
+  container: 'w-full',
+  horizontal: 'flex',
 };
+
 
 export const card = {
   card: 'cursor-pointer overflow-hidden relative transition-all',

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -89,7 +89,6 @@ export const steps = {
   horizontal: 'flex',
 };
 
-
 export const card = {
   card: 'cursor-pointer overflow-hidden relative transition-all',
   cardShadow: 'group rounded-8 s-surface-elevated-200 hover:s-surface-elevated-200-hover active:s-surface-elevated-200-active',
@@ -413,8 +412,10 @@ export const input = {
 export const select = {
   base: 'block text-m mb-0 py-12 pr-32 rounded-4 w-full focusable focus:[--w-outline-offset:-2px] appearance-none cursor-pointer caret-current',
   default: 's-text s-bg pl-8 border-1 s-border hover:s-border-hover active:s-border-active',
-  disabled: ' s-text-disabled s-bg-disabled-subtle pl-8 border-1 s-border-disabled hover:s-border-disabled active:s-border-disabled pointer-events-none',
-  invalid: 's-text s-bg pl-8 border-1 s-border-negative hover:s-border-negative-hover active:s-border-active outline-[--w-s-color-border-negative]!',
+  disabled:
+    ' s-text-disabled s-bg-disabled-subtle pl-8 border-1 s-border-disabled hover:s-border-disabled active:s-border-disabled pointer-events-none',
+  invalid:
+    's-text s-bg pl-8 border-1 s-border-negative hover:s-border-negative-hover active:s-border-active outline-[--w-s-color-border-negative]!',
   readOnly: 's-text bg-transparent pl-0 border-0 pointer-events-none before:hidden',
   wrapper: 'relative',
   selectWrapper: `relative before:block before:absolute before:right-0 before:bottom-0 before:w-32 before:h-full before:pointer-events-none `,

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -56,7 +56,7 @@ export const pill = {
 };
 
 export const step = {
-  step: 'group/step',
+  container: 'group/step',
   vertical: 'group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16',
   horizontal: 'group/steph grid-rows-[auto_20px] grid-cols-[1fr_20px_1fr] flex-1 grid gap-y-16 items-center',
 

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -63,13 +63,13 @@ export const step = {
   alignLeft: 'grid-cols-[20px_1fr]',
   alignRight: 'grid-cols-[1fr_20px] text-right',
 
-  stepDot: 'rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted',
+  dot: 'rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted',
   dotAlignRight: 'col-start-2',
   dotHorizontal: 'row-start-2 justify-self-end',
   dotActive: 's-border-primary s-bg-primary',
   dotIncomplete: 's-border s-bg',
 
-  stepLine: 'group-last/stepv:hidden transition-colors duration-300',
+  line: 'group-last/stepv:hidden transition-colors duration-300',
   lineVertical: 'w-2 h-full justify-self-center',
   lineAlignRight: 'col-start-2',
   lineHorizontal: 'h-2 w-full row-start-2',


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the Step and Steps components.

**Changes:**
- Renamed `step` and `steps` classes for better readability


## Testing
Tested the changes in @warp-ds/react and @warp-ds/vue (`fix/clean-up-step-classes` branch)