### PR TITLE
fix(toast): clean up classes

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -117,14 +117,15 @@ export namespace toaster {
 export namespace toast {
     let wrapper_2: string;
     export { wrapper_2 as wrapper };
-    export let toast: string;
+    let base_1: string;
+    export { base_1 as base };
     let positive_1: string;
     export { positive_1 as positive };
     let warning_1: string;
     export { warning_1 as warning };
     let negative_1: string;
     export { negative_1 as negative };
-    export let icon: string;
+    export let iconBase: string;
     export let iconPositive: string;
     export let iconWarning: string;
     export let iconNegative: string;
@@ -143,8 +144,7 @@ export namespace tab {
     export let tab: string;
     export let tabInactive: string;
     export let tabActive: string;
-    let icon_1: string;
-    export { icon_1 as icon };
+    export let icon: string;
     let content_3: string;
     export { content_3 as content };
     export let contentUnderlined: string;
@@ -311,8 +311,8 @@ export namespace alert {
     export let textWrapper: string;
     let title_2: string;
     export { title_2 as title };
-    let icon_2: string;
-    export { icon_2 as icon };
+    let icon_1: string;
+    export { icon_1 as icon };
     let negative_3: string;
     export { negative_3 as negative };
     export let negativeIcon: string;
@@ -329,8 +329,8 @@ export namespace alert {
 export namespace input {
     let wrapper_5: string;
     export { wrapper_5 as wrapper };
-    let base_1: string;
-    export { base_1 as base };
+    let base_2: string;
+    export { base_2 as base };
     let _default: string;
     export { _default as default };
     let disabled_1: string;
@@ -343,8 +343,8 @@ export namespace input {
     export let textArea: string;
 }
 export namespace select {
-    let base_2: string;
-    export { base_2 as base };
+    let base_3: string;
+    export { base_3 as base };
     let _default_1: string;
     export { _default_1 as default };
     let disabled_2: string;
@@ -454,8 +454,8 @@ export namespace combobox {
     export { a11y_6 as a11y };
 }
 export namespace attention {
-    let base_3: string;
-    export { base_3 as base };
+    let base_4: string;
+    export { base_4 as base };
     export let tooltip: string;
     export let callout: string;
     export let highlight: string;
@@ -486,8 +486,8 @@ export namespace pagination {
     let link_2: string;
     export { link_2 as link };
     export let currentPage: string;
-    let icon_3: string;
-    export { icon_3 as icon };
+    let icon_2: string;
+    export { icon_2 as icon };
     export let containerNav: string;
     let a11y_7: string;
     export { a11y_7 as a11y };

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -124,11 +124,11 @@ export const toaster = {
 
 export const toast = {
   wrapper: 'relative overflow-hidden w-full',
-  toast: 'flex group p-8 mt-16 rounded-8 border-2 w-full pointer-events-auto transition-all',
+  base: 'flex group p-8 mt-16 rounded-8 border-2 pointer-events-auto transition-all',
   positive: 's-bg-positive-subtle s-border-positive-subtle s-text',
   warning: 's-bg-warning-subtle s-border-warning-subtle s-text',
   negative: 's-bg-negative-subtle s-border-negative-subtle s-text',
-  icon: 'shrink-0 rounded-full w-[16px] h-[16px] m-[8px]',
+  iconBase: 'shrink-0 rounded-full w-[16px] h-[16px] m-[8px]',
   iconPositive: 's-icon-positive',
   iconWarning: 's-icon-warning',
   iconNegative: 's-icon-negative',
@@ -411,8 +411,10 @@ export const input = {
 export const select = {
   base: 'block text-m mb-0 py-12 pr-32 rounded-4 w-full focusable focus:[--w-outline-offset:-2px] appearance-none cursor-pointer caret-current',
   default: 's-text s-bg pl-8 border-1 s-border hover:s-border-hover active:s-border-active',
-  disabled: ' s-text-disabled s-bg-disabled-subtle pl-8 border-1 s-border-disabled hover:s-border-disabled active:s-border-disabled pointer-events-none',
-  invalid: 's-text s-bg pl-8 border-1 s-border-negative hover:s-border-negative-hover active:s-border-active outline-[--w-s-color-border-negative]!',
+  disabled:
+    ' s-text-disabled s-bg-disabled-subtle pl-8 border-1 s-border-disabled hover:s-border-disabled active:s-border-disabled pointer-events-none',
+  invalid:
+    's-text s-bg pl-8 border-1 s-border-negative hover:s-border-negative-hover active:s-border-active outline-[--w-s-color-border-negative]!',
   readOnly: 's-text bg-transparent pl-0 border-0 pointer-events-none before:hidden',
   wrapper: 'relative',
   selectWrapper: `relative before:block before:absolute before:right-0 before:bottom-0 before:w-32 before:h-full before:pointer-events-none `,


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the `Toast` component.

**Changes:**
- Renamed `toast` classes for better readability
- Removed redundant use of `w-full` in `base` class (previously named `toast` class).


## Testing
Tested the changes in @warp-ds/elements (`fix/clean-up-toast-classes` branch)