### PR TITLE
fix(combobox): clean up classes

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -448,7 +448,7 @@ export namespace combobox {
     let base_3: string;
     export { base_3 as base };
     export let listbox: string;
-    export let optionBase: string;
+    export let option: string;
     export let optionUnselected: string;
     export let optionSelected: string;
     export let textMatch: string;

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -445,17 +445,19 @@ export namespace clickable {
 export namespace combobox {
     let wrapper_12: string;
     export { wrapper_12 as wrapper };
-    export let combobox: string;
-    export let textMatch: string;
+    let base_3: string;
+    export { base_3 as base };
     export let listbox: string;
-    export let option: string;
+    export let optionBase: string;
+    export let optionUnselected: string;
     export let optionSelected: string;
+    export let textMatch: string;
     let a11y_6: string;
     export { a11y_6 as a11y };
 }
 export namespace attention {
-    let base_3: string;
-    export { base_3 as base };
+    let base_4: string;
+    export { base_4 as base };
     export let tooltip: string;
     export let callout: string;
     export let highlight: string;

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -517,11 +517,12 @@ export const clickable = {
 
 export const combobox = {
   wrapper: 'relative',
-  combobox: 'absolute left-0 right-0 pb-8 rounded-8 s-bg shadow-m',
-  textMatch: 'font-bold',
+  base: 'absolute left-0 right-0 pb-8 rounded-8 shadow-m',
   listbox: 'm-0 p-0 select-none list-none',
-  option: 'block cursor-pointer p-8 hover:s-bg-hover',
+  optionBase: 'block cursor-pointer p-8',
+  optionUnselected: 's-bg hover:s-bg-hover',
   optionSelected: 's-bg-selected hover:s-bg-selected-hover',
+  textMatch: 'font-bold',
   a11y: 'sr-only',
 };
 

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -519,7 +519,7 @@ export const combobox = {
   wrapper: 'relative',
   base: 'absolute left-0 right-0 pb-8 rounded-8 shadow-m',
   listbox: 'm-0 p-0 select-none list-none',
-  optionBase: 'block cursor-pointer p-8',
+  option: 'block cursor-pointer p-8',
   optionUnselected: 's-bg hover:s-bg-hover',
   optionSelected: 's-bg-selected hover:s-bg-selected-hover',
   textMatch: 'font-bold',


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the `Combobox` component.

**Changes:**
- Renamed and restructured `combobox` classes for better readability

## Testing
Tested the changes in @warp-ds/react (`fix/add-tests-combo-box` branch)