### PR TITLE
fix(buttongroup): clean up classes

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -267,7 +267,9 @@ export namespace buttonGroupItem {
     export let outlinedHorizontal: string;
     export let outlinedVerticalResets: string;
     export let outlinedHorizontalResets: string;
+    export let outlinedUnselected: string;
     export let outlinedSelected: string;
+    export let unSelected: string;
     export let selected: string;
 }
 export namespace modal {

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -414,7 +414,7 @@ export const select = {
   base: 'block text-m mb-0 py-12 pr-32 rounded-4 w-full focusable focus:[--w-outline-offset:-2px] appearance-none cursor-pointer caret-current',
   default: 's-text s-bg pl-8 border-1 s-border hover:s-border-hover active:s-border-active',
   disabled:
-    ' s-text-disabled s-bg-disabled-subtle pl-8 border-1 s-border-disabled hover:s-border-disabled active:s-border-disabled pointer-events-none',
+    's-text-disabled s-bg-disabled-subtle pl-8 border-1 s-border-disabled hover:s-border-disabled active:s-border-disabled pointer-events-none',
   invalid:
     's-text s-bg pl-8 border-1 s-border-negative hover:s-border-negative-hover active:s-border-active outline-[--w-s-color-border-negative]!',
   readOnly: 's-text bg-transparent pl-0 border-0 pointer-events-none before:hidden',

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -323,14 +323,16 @@ export const buttonGroup = {
 
 export const buttonGroupItem = {
   wrapper:
-    'relative s-text s-bg hover:bg-[--w-color-buttongroup-utility-background-hover] active:s-text active:bg-[--w-color-buttongroup-utility-background-selected]',
-  outlined: 'border hover:z-30 border-[--w-color-buttongroup-utility-border] active:border-[--w-color-buttongroup-utility-border-selected]',
+    'relative s-text',
+  outlined: 'border hover:z-30',
   outlinedVertical: '-mb-1 last:mb-0 first:rounded-lt-4 first:rounded-rt-4 last:rounded-lb-4 last:rounded-rb-4',
   outlinedHorizontal: '-mr-1 last:mr-0 first:rounded-lt-4 first:rounded-lb-4 last:rounded-rt-4 last:rounded-rb-4',
   outlinedVerticalResets: 'px-1 pt-1 last:pb-1 -mb-1 last:mb-0',
   outlinedHorizontalResets: 'py-1 pl-1 last:pr-1 -mr-1 last:mr-0',
+  outlinedUnselected: 'border-[--w-color-buttongroup-utility-border] active:border-[--w-color-buttongroup-utility-border-selected]',
   outlinedSelected: 'border-[--w-color-buttongroup-utility-border-selected]',
-  selected: 'z-30 s-text! bg-[--w-color-buttongroup-utility-background-selected]!',
+  unSelected: 's-bg hover:bg-[--w-color-buttongroup-utility-background-hover] active:s-text active:bg-[--w-color-buttongroup-utility-background-selected]',
+  selected: 'z-30 bg-[--w-color-buttongroup-utility-background-selected]',
 };
 
 export const modal = {

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -322,8 +322,7 @@ export const buttonGroup = {
 };
 
 export const buttonGroupItem = {
-  wrapper:
-    'relative s-text',
+  wrapper: 'relative s-text',
   outlined: 'border hover:z-30',
   outlinedVertical: '-mb-1 last:mb-0 first:rounded-lt-4 first:rounded-rt-4 last:rounded-lb-4 last:rounded-rb-4',
   outlinedHorizontal: '-mr-1 last:mr-0 first:rounded-lt-4 first:rounded-lb-4 last:rounded-rt-4 last:rounded-rb-4',
@@ -331,7 +330,8 @@ export const buttonGroupItem = {
   outlinedHorizontalResets: 'py-1 pl-1 last:pr-1 -mr-1 last:mr-0',
   outlinedUnselected: 'border-[--w-color-buttongroup-utility-border] active:border-[--w-color-buttongroup-utility-border-selected]',
   outlinedSelected: 'border-[--w-color-buttongroup-utility-border-selected]',
-  unSelected: 's-bg hover:bg-[--w-color-buttongroup-utility-background-hover] active:s-text active:bg-[--w-color-buttongroup-utility-background-selected]',
+  unSelected:
+    's-bg hover:bg-[--w-color-buttongroup-utility-background-hover] active:s-text active:bg-[--w-color-buttongroup-utility-background-selected]',
   selected: 'z-30 bg-[--w-color-buttongroup-utility-background-selected]',
 };
 
@@ -413,8 +413,10 @@ export const input = {
 export const select = {
   base: 'block text-m mb-0 py-12 pr-32 rounded-4 w-full focusable focus:[--w-outline-offset:-2px] appearance-none cursor-pointer caret-current',
   default: 's-text s-bg pl-8 border-1 s-border hover:s-border-hover active:s-border-active',
-  disabled: ' s-text-disabled s-bg-disabled-subtle pl-8 border-1 s-border-disabled hover:s-border-disabled active:s-border-disabled pointer-events-none',
-  invalid: 's-text s-bg pl-8 border-1 s-border-negative hover:s-border-negative-hover active:s-border-active outline-[--w-s-color-border-negative]!',
+  disabled:
+    ' s-text-disabled s-bg-disabled-subtle pl-8 border-1 s-border-disabled hover:s-border-disabled active:s-border-disabled pointer-events-none',
+  invalid:
+    's-text s-bg pl-8 border-1 s-border-negative hover:s-border-negative-hover active:s-border-active outline-[--w-s-color-border-negative]!',
   readOnly: 's-text bg-transparent pl-0 border-0 pointer-events-none before:hidden',
   wrapper: 'relative',
   selectWrapper: `relative before:block before:absolute before:right-0 before:bottom-0 before:w-32 before:h-full before:pointer-events-none `,


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the `ButtonGroup` component.

**Changes:**
- Renamed and restructured `buttonGroupItem` classes for better readability

## Testing
Tested the changes in @warp-ds/vue (`fix/cleanup-button-group-classes` branch)