### PR TITLE
fix(slider): clean up classes 

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -26,6 +26,7 @@ export namespace slider {
     export let track: string;
     export let trackDisabled: string;
     export let activeTrack: string;
+    export let activeTrackEnabled: string;
     export let activeTrackDisabled: string;
     export let thumb: string;
     export let thumbEnabled: string;
@@ -452,8 +453,8 @@ export namespace clickable {
 export namespace combobox {
     let wrapper_12: string;
     export { wrapper_12 as wrapper };
-    let base_3: string;
-    export { base_3 as base };
+    let base_4: string;
+    export { base_4 as base };
     export let listbox: string;
     export let option: string;
     export let optionUnselected: string;
@@ -463,8 +464,8 @@ export namespace combobox {
     export { a11y_6 as a11y };
 }
 export namespace attention {
-    let base_4: string;
-    export { base_4 as base };
+    let base_5: string;
+    export { base_5 as base };
     export let tooltip: string;
     export let callout: string;
     export let highlight: string;

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -26,8 +26,9 @@ export const slider = {
   wrapper: 'touch-pan-y relative w-full h-44 py-2',
   track: 'absolute s-bg-disabled-subtle h-4 top-20 rounded-4 w-full',
   trackDisabled: 'pointer-events-none',
-  activeTrack: 'absolute s-bg-primary h-6 top-[19px] rounded-4',
-  activeTrackDisabled: 'absolute s-bg-disabled h-6 top-[19px] rounded-4 pointer-events-none',
+  activeTrack: 'absolute h-6 top-[19px] rounded-4',
+  activeTrackEnabled: 's-bg-primary',
+  activeTrackDisabled: 's-bg-disabled pointer-events-none',
   thumb: 'absolute transition-shadow w-24 h-24 bottom-10 rounded-4 outline-none',
   thumbEnabled:
     'border-2 shadow-[--w-shadow-slider] cursor-pointer s-bg-primary s-border-primary hover:s-bg-primary-hover hover:s-border-primary-hover hover:shadow-[--w-shadow-slider-handle-hover] active:s-bg-primary-active active:s-border-primary-active active:shadow-[--w-shadow-slider-handle-active] focus:shadow-[--w-shadow-slider-handle-hover] focus:s-border-primary-hover focus:s-bg-primary-hover',

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -24,7 +24,7 @@ export const badge = {
 
 export const slider = {
   wrapper: 'touch-pan-y relative w-full h-44 py-2',
-  track: 'absolute s-bg-disabled-subtle h-4 top-20 rounded-4 w-full ',
+  track: 'absolute s-bg-disabled-subtle h-4 top-20 rounded-4 w-full',
   trackDisabled: 'pointer-events-none',
   activeTrack: 'absolute s-bg-primary h-6 top-[19px] rounded-4',
   activeTrackDisabled: 'absolute s-bg-disabled h-6 top-[19px] rounded-4 pointer-events-none',


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the `Slider` component.

**Changes:**
- Move `s-bg-primary` to the new class`activeTrackEnabled`
- Remove blank space in `track` class


## Testing
Tested the changes in @warp-ds/react and @warp-ds/vue (`fix/cleanup-slider-classes` branch)