### PR TITLE
fix(expandable): clean up classes

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -184,7 +184,7 @@ export namespace expandable {
     let button_1: string;
     export { button_1 as button };
     export let buttonBox: string;
-    export let paddingTop: string;
+    export let contentWithTitle: string;
     export let title: string;
     export let titleType: string;
 }

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -169,9 +169,7 @@ export const buttonReset: "focus:outline-none appearance-none cursor-pointer bg-
 export namespace expandable {
     export let expandable: string;
     export let expandableBox: string;
-    export let expandableInfo: string;
-    import expandableBleed = box.bleed;
-    export { expandableBleed };
+    export let expandableBleed: string;
     export let chevron: string;
     export let chevronNonBox: string;
     export let chevronTransform: string;

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -168,7 +168,6 @@ export namespace gridLayout {
 export const buttonReset: "focus:outline-none appearance-none cursor-pointer bg-transparent border-0 m-0 p-0 inline-block";
 export namespace expandable {
     export let expandable: string;
-    export let expandableTitle: string;
     export let expandableBox: string;
     export let expandableInfo: string;
     import expandableBleed = box.bleed;

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -179,8 +179,8 @@ export namespace expandable {
     export let chevronExpand: string;
     export let chevronCollapse: string;
     export let elementsTransformChevronDownPart: string;
-    export let elementsChevronDownExpandPart: string;
     export let elementsTransformChevronUpPart: string;
+    export let elementsChevronDownExpandPart: string;
     export let elementsChevronUpCollapsePart: string;
     export let expansion: string;
     export let expansionNotExpanded: string;

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -178,10 +178,10 @@ export namespace expandable {
     export let chevronTransform: string;
     export let chevronExpand: string;
     export let chevronCollapse: string;
-    export let elementsTransformChevronDownPart: string;
-    export let elementsTransformChevronUpPart: string;
-    export let elementsChevronDownExpandPart: string;
-    export let elementsChevronUpCollapsePart: string;
+    export let elementsChevronDownTransform: string;
+    export let elementsChevronUpTransform: string;
+    export let elementsChevronExpand: string;
+    export let elementsChevronCollapse: string;
     export let expansion: string;
     export let expansionNotExpanded: string;
     let button_1: string;

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -175,7 +175,6 @@ export namespace expandable {
     export { expandableBleed };
     export let chevron: string;
     export let chevronNonBox: string;
-    export let chevronBox: string;
     export let chevronTransform: string;
     export let chevronExpand: string;
     export let chevronCollapse: string;

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -170,8 +170,7 @@ export const gridLayout = {
 export const buttonReset = 'focus:outline-none appearance-none cursor-pointer bg-transparent border-0 m-0 p-0 inline-block';
 
 export const expandable = {
-  expandable: 'will-change-height',
-  expandableTitle: 'font-bold s-text',
+  expandable: 'will-change-height s-text',
   expandableBox: 's-surface-sunken hover:s-bg-hover active:s-bg-active py-0 px-0 ' + box.box,
   expandableInfo: 's-bg-info-subtle! hover:s-bg-info-subtle-hover!',
   expandableBleed: box.bleed,

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -180,6 +180,7 @@ export const expandable = {
   chevronTransform: 'transform transition-transform transform-gpu ease-in-out',
   chevronExpand: '-rotate-180',
   chevronCollapse: 'rotate-180',
+  
   // These are web component specific classes, using the ::part-selector:
   elementsChevronDownTransform:
     'part-[w-icon-chevron-down-16-part]:transform part-[w-icon-chevron-down-16-part]:transition-transform part-[w-icon-chevron-down-16-part]:transform-gpu part-[w-icon-chevron-down-16-part]:ease-in-out',

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -182,9 +182,9 @@ export const expandable = {
   chevronCollapse: 'rotate-180',
   elementsTransformChevronDownPart:
     'part-[w-icon-chevron-down-16-part]:transform part-[w-icon-chevron-down-16-part]:transition-transform part-[w-icon-chevron-down-16-part]:transform-gpu part-[w-icon-chevron-down-16-part]:ease-in-out',
-  elementsChevronDownExpandPart: 'part-[w-icon-chevron-down-16-part]:-rotate-180',
   elementsTransformChevronUpPart:
     'part-[w-icon-chevron-up-16-part]:transform part-[w-icon-chevron-up-16-part]:transition-transform part-[w-icon-chevron-up-16-part]:transform-gpu part-[w-icon-chevron-up-16-part]:ease-in-out',
+  elementsChevronDownExpandPart: 'part-[w-icon-chevron-down-16-part]:-rotate-180',
   elementsChevronUpCollapsePart: 'part-[w-icon-chevron-up-16-part]:rotate-180',
   expansion: 'overflow-hidden',
   expansionNotExpanded: 'h-0 invisible',

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -180,12 +180,14 @@ export const expandable = {
   chevronTransform: 'transform transition-transform transform-gpu ease-in-out',
   chevronExpand: '-rotate-180',
   chevronCollapse: 'rotate-180',
-  elementsTransformChevronDownPart:
+  // These are web component specific classes, using the ::part-selector:
+  elementsChevronDownTransform:
     'part-[w-icon-chevron-down-16-part]:transform part-[w-icon-chevron-down-16-part]:transition-transform part-[w-icon-chevron-down-16-part]:transform-gpu part-[w-icon-chevron-down-16-part]:ease-in-out',
-  elementsTransformChevronUpPart:
+  elementsChevronUpTransform:
     'part-[w-icon-chevron-up-16-part]:transform part-[w-icon-chevron-up-16-part]:transition-transform part-[w-icon-chevron-up-16-part]:transform-gpu part-[w-icon-chevron-up-16-part]:ease-in-out',
-  elementsChevronDownExpandPart: 'part-[w-icon-chevron-down-16-part]:-rotate-180',
-  elementsChevronUpCollapsePart: 'part-[w-icon-chevron-up-16-part]:rotate-180',
+  elementsChevronExpand: 'part-[w-icon-chevron-down-16-part]:-rotate-180',
+  elementsChevronCollapse: 'part-[w-icon-chevron-up-16-part]:rotate-180',
+
   expansion: 'overflow-hidden',
   expansionNotExpanded: 'h-0 invisible',
   button: buttonReset + ' hover:underline focus-visible:underline',

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -177,7 +177,6 @@ export const expandable = {
   expandableBleed: box.bleed,
   chevron: 'inline-block align-middle s-icon',
   chevronNonBox: 'ml-8',
-  chevronBox: '',
   chevronTransform: 'transform transition-transform transform-gpu ease-in-out',
   chevronExpand: '-rotate-180',
   chevronCollapse: 'rotate-180',

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -192,9 +192,9 @@ export const expandable = {
   expansionNotExpanded: 'h-0 invisible',
   button: 'focus:outline-none appearance-none cursor-pointer bg-transparent border-0 m-0 hover:underline focus-visible:underline',
   buttonBox: 'w-full text-left relative inline-flex items-center justify-between group relative break-words last-child:mb-0 p-16 rounded-8',
-  paddingTop: 'pt-0',
+  contentWithTitle: 'pt-0',
   title: 'flex w-full justify-between items-center',
-  titleType: 'h4',
+  titleType: 't4',
 };
 
 const buttonDefaultStyling = 'font-bold focusable justify-center transition-colors ease-in-out';

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -180,7 +180,7 @@ export const expandable = {
   chevronTransform: 'transform transition-transform transform-gpu ease-in-out',
   chevronExpand: '-rotate-180',
   chevronCollapse: 'rotate-180',
-  
+
   // These are web component specific classes, using the ::part-selector:
   elementsChevronDownTransform:
     'part-[w-icon-chevron-down-16-part]:transform part-[w-icon-chevron-down-16-part]:transition-transform part-[w-icon-chevron-down-16-part]:transform-gpu part-[w-icon-chevron-down-16-part]:ease-in-out',

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -171,7 +171,8 @@ export const buttonReset = 'focus:outline-none appearance-none cursor-pointer bg
 
 export const expandable = {
   expandable: 'will-change-height s-text',
-  expandableBox: 's-surface-sunken hover:s-bg-hover active:s-bg-active py-0 px-0 group block relative break-words last-child:mb-0 rounded-8',
+  expandableBox:
+    's-surface-sunken hover:s-bg-hover active:s-bg-active py-0 px-0 group block relative break-words last-child:mb-0 rounded-8',
   expandableBleed: '-mx-16 rounded-l-0 rounded-r-0 sm:mx-0 sm:rounded-8',
   chevron: 'inline-block align-middle s-icon',
   chevronNonBox: 'ml-8',

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -171,9 +171,8 @@ export const buttonReset = 'focus:outline-none appearance-none cursor-pointer bg
 
 export const expandable = {
   expandable: 'will-change-height s-text',
-  expandableBox: 's-surface-sunken hover:s-bg-hover active:s-bg-active py-0 px-0 ' + box.box,
-  expandableInfo: 's-bg-info-subtle! hover:s-bg-info-subtle-hover!',
-  expandableBleed: box.bleed,
+  expandableBox: 's-surface-sunken hover:s-bg-hover active:s-bg-active py-0 px-0 group block relative break-words last-child:mb-0 rounded-8',
+  expandableBleed: '-mx-16 rounded-l-0 rounded-r-0 sm:mx-0 sm:rounded-8',
   chevron: 'inline-block align-middle s-icon',
   chevronNonBox: 'ml-8',
   chevronTransform: 'transform transition-transform transform-gpu ease-in-out',
@@ -190,8 +189,8 @@ export const expandable = {
 
   expansion: 'overflow-hidden',
   expansionNotExpanded: 'h-0 invisible',
-  button: buttonReset + ' hover:underline focus-visible:underline',
-  buttonBox: 'w-full text-left relative inline-flex items-center justify-between ' + box.box,
+  button: 'focus:outline-none appearance-none cursor-pointer bg-transparent border-0 m-0 hover:underline focus-visible:underline',
+  buttonBox: 'w-full text-left relative inline-flex items-center justify-between group relative break-words last-child:mb-0 p-16 rounded-8',
   paddingTop: 'pt-0',
   title: 'flex w-full justify-between items-center',
   titleType: 'h4',


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the Expandable component.

**Changes:**
- Remove `expandableTitle` (was only used in Vue) and move `s-text` to `expandable` wrapper class
- Remove `expandableInfo` since `info` has been deprecated
- Remove `chevronBox` class that was just setting an empty string
- Rename elements-specific classes and specify that they are only used in elements
- Rename `paddingTop` to `contentWithTitle`
- Replace `h4` with `t4` in the `titleType` class


## Testing
Tested the changes in @warp-ds/react, @warp-ds/vue and @warp-ds/elements (`fix/cleanup-expandable-component` branch)