### PR TITLE
fix(card): clean up classes

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -84,15 +84,14 @@ export namespace steps {
 }
 export namespace card {
     export let card: string;
-    export let cardShadow: string;
-    export let cardShadowBackground: string;
-    export let cardSelected: string;
-    export let cardOutline: string;
-    export let cardOutlineUnselected: string;
-    export let cardOutlineSelected: string;
-    export let cardFlat: string;
-    export let cardFlatUnselected: string;
-    export let cardFlatSelected: string;
+    export let shadow: string;
+    export let selected: string;
+    export let outline: string;
+    export let outlineUnselected: string;
+    export let outlineSelected: string;
+    export let flat: string;
+    export let flatUnselected: string;
+    export let flatSelected: string;
     let a11y_1: string;
     export { a11y_1 as a11y };
 }
@@ -273,7 +272,8 @@ export namespace buttonGroupItem {
     export let outlinedUnselected: string;
     export let outlinedSelected: string;
     export let unSelected: string;
-    export let selected: string;
+    let selected_1: string;
+    export { selected_1 as selected };
 }
 export namespace modal {
     export let backdrop: string;

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -85,6 +85,7 @@ export namespace steps {
 export namespace card {
     export let card: string;
     export let cardShadow: string;
+    export let cardShadowBackground: string;
     export let cardSelected: string;
     export let cardOutline: string;
     export let cardOutlineUnselected: string;

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -83,7 +83,8 @@ export namespace steps {
     export { horizontal_1 as horizontal };
 }
 export namespace card {
-    export let card: string;
+    let base_1: string;
+    export { base_1 as base };
     export let shadow: string;
     export let selected: string;
     export let outline: string;
@@ -122,8 +123,8 @@ export namespace toaster {
 export namespace toast {
     let wrapper_2: string;
     export { wrapper_2 as wrapper };
-    let base_1: string;
-    export { base_1 as base };
+    let base_2: string;
+    export { base_2 as base };
     let positive_1: string;
     export { positive_1 as positive };
     let warning_1: string;
@@ -334,8 +335,8 @@ export namespace alert {
 export namespace input {
     let wrapper_5: string;
     export { wrapper_5 as wrapper };
-    let base_2: string;
-    export { base_2 as base };
+    let base_3: string;
+    export { base_3 as base };
     let _default: string;
     export { _default as default };
     let disabled_1: string;
@@ -348,8 +349,8 @@ export namespace input {
     export let textArea: string;
 }
 export namespace select {
-    let base_3: string;
-    export { base_3 as base };
+    let base_4: string;
+    export { base_4 as base };
     let _default_1: string;
     export { _default_1 as default };
     let disabled_2: string;
@@ -450,8 +451,8 @@ export namespace clickable {
 export namespace combobox {
     let wrapper_12: string;
     export { wrapper_12 as wrapper };
-    let base_4: string;
-    export { base_4 as base };
+    let base_5: string;
+    export { base_5 as base };
     export let listbox: string;
     export let option: string;
     export let optionUnselected: string;
@@ -461,8 +462,8 @@ export namespace combobox {
     export { a11y_6 as a11y };
 }
 export namespace attention {
-    let base_5: string;
-    export { base_5 as base };
+    let base_6: string;
+    export { base_6 as base };
     export let tooltip: string;
     export let callout: string;
     export let highlight: string;

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -91,7 +91,7 @@ export const steps = {
 };
 
 export const card = {
-  card: 'cursor-pointer overflow-hidden relative transition-all',
+  base: 'cursor-pointer overflow-hidden relative transition-all',
   shadow: 'group rounded-8 s-surface-elevated-200 hover:s-surface-elevated-200-hover active:s-surface-elevated-200-active',
   selected: '!s-bg-selected !hover:s-bg-selected-hover !active:s-bg-selected-active',
   outline: 'absolute border-2 rounded-8 inset-0 transition-all',

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -92,15 +92,14 @@ export const steps = {
 
 export const card = {
   card: 'cursor-pointer overflow-hidden relative transition-all',
-  cardShadow: 'group rounded-8',
-  cardShadowBackground: 's-surface-elevated-200 hover:s-surface-elevated-200-hover active:s-surface-elevated-200-active',
-  cardSelected: 's-bg-selected hover:s-bg-selected-hover active:s-bg-selected-active',
-  cardOutline: 'absolute border-2 rounded-8 inset-0 transition-all',
-  cardOutlineUnselected: 'border-transparent group-active:s-border-active',
-  cardOutlineSelected: 's-border-selected group-hover:s-border-selected-hover group-active:s-border-selected-active',
-  cardFlat: 'border-2 rounded-4',
-  cardFlatUnselected: 's-bg hover:s-bg-hover active:s-bg-active s-border hover:s-border-hover active:s-border-active',
-  cardFlatSelected:
+  shadow: 'group rounded-8 s-surface-elevated-200 hover:s-surface-elevated-200-hover active:s-surface-elevated-200-active',
+  selected: '!s-bg-selected !hover:s-bg-selected-hover !active:s-bg-selected-active',
+  outline: 'absolute border-2 rounded-8 inset-0 transition-all',
+  outlineUnselected: 'border-transparent group-active:s-border-active',
+  outlineSelected: 's-border-selected group-hover:s-border-selected-hover group-active:s-border-selected-active',
+  flat: 'border-2 rounded-4',
+  flatUnselected: 's-bg hover:s-bg-hover active:s-bg-active s-border hover:s-border-hover active:s-border-active',
+  flatSelected:
     's-bg-selected hover:s-bg-selected-hover active:s-bg-selected-active s-border-selected hover:s-border-selected-hover active:s-border-selected-active',
   a11y: 'sr-only',
 };

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -93,7 +93,7 @@ export const steps = {
 export const card = {
   card: 'cursor-pointer overflow-hidden relative transition-all',
   cardShadow: 'group rounded-8',
-  cardShadowBackground: ' s-surface-elevated-200 hover:s-surface-elevated-200-hover active:s-surface-elevated-200-active',
+  cardShadowBackground: 's-surface-elevated-200 hover:s-surface-elevated-200-hover active:s-surface-elevated-200-active',
   cardSelected: 's-bg-selected hover:s-bg-selected-hover active:s-bg-selected-active',
   cardOutline: 'absolute border-2 rounded-8 inset-0 transition-all',
   cardOutlineUnselected: 'border-transparent group-active:s-border-active',

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -92,8 +92,9 @@ export const steps = {
 
 export const card = {
   card: 'cursor-pointer overflow-hidden relative transition-all',
-  cardShadow: 'group rounded-8 s-surface-elevated-200 hover:s-surface-elevated-200-hover active:s-surface-elevated-200-active',
-  cardSelected: '!s-bg-selected !hover:s-bg-selected-hover !active:s-bg-selected-active',
+  cardShadow: 'group rounded-8',
+  cardShadowBackground: ' s-surface-elevated-200 hover:s-surface-elevated-200-hover active:s-surface-elevated-200-active',
+  cardSelected: 's-bg-selected hover:s-bg-selected-hover active:s-bg-selected-active',
   cardOutline: 'absolute border-2 rounded-8 inset-0 transition-all',
   cardOutlineUnselected: 'border-transparent group-active:s-border-active',
   cardOutlineSelected: 's-border-selected group-hover:s-border-selected-hover group-active:s-border-selected-active',


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the Card component.

**Changes:**
- Remove redundant use of `card` in card-classes
- Rename `card` class to `base`


## Testing
Tested the changes in @warp-ds/react, @warp-ds/vue and @warp-ds/elements (`fix/cleanup-card-classes` branch)