### PR TITLE
fix: rename classnames and restructure component-classes file

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -33,7 +33,8 @@ export namespace slider {
     export let thumbDisabled: string;
 }
 export namespace box {
-    export let box: string;
+    let base_1: string;
+    export { base_1 as base };
     export let bleed: string;
     let info_1: string;
     export { info_1 as info };
@@ -42,15 +43,16 @@ export namespace box {
     export let bordered: string;
 }
 export namespace pill {
-    let pill: string;
-    let button: string;
-    let suggestion: string;
-    let filter: string;
-    let label: string;
-    let labelWithoutClose: string;
-    let labelWithClose: string;
-    let close: string;
-    let a11y: string;
+    let wrapper_2: string;
+    export { wrapper_2 as wrapper };
+    export let button: string;
+    export let suggestion: string;
+    export let filter: string;
+    export let label: string;
+    export let labelWithoutClose: string;
+    export let labelWithClose: string;
+    export let close: string;
+    export let a11y: string;
 }
 export namespace step {
     export let container: string;
@@ -83,8 +85,8 @@ export namespace steps {
     export { horizontal_1 as horizontal };
 }
 export namespace card {
-    let base_1: string;
-    export { base_1 as base };
+    let base_2: string;
+    export { base_2 as base };
     export let shadow: string;
     export let selected: string;
     export let outline: string;
@@ -116,15 +118,16 @@ export namespace switchToggle {
 export namespace toaster {
     let container_2: string;
     export { container_2 as container };
+    let base_3: string;
+    export { base_3 as base };
     let content_1: string;
     export { content_1 as content };
-    export let toaster: string;
 }
 export namespace toast {
-    let wrapper_2: string;
-    export { wrapper_2 as wrapper };
-    let base_2: string;
-    export { base_2 as base };
+    let wrapper_3: string;
+    export { wrapper_3 as wrapper };
+    let base_4: string;
+    export { base_4 as base };
     let positive_1: string;
     export { positive_1 as positive };
     let warning_1: string;
@@ -142,14 +145,19 @@ export namespace toast {
     export { close_1 as close };
 }
 export namespace tabs {
-    let tabContainer: string;
-    let wunderbar: string;
-    let wrapperUnderlined: string;
+    let wrapper_4: string;
+    export { wrapper_4 as wrapper };
+    let container_3: string;
+    export { container_3 as container };
+    export let selectionIndicator: string;
 }
 export namespace tab {
-    export let tab: string;
-    export let tabInactive: string;
-    export let tabActive: string;
+    let base_5: string;
+    export { base_5 as base };
+    let inactive_1: string;
+    export { inactive_1 as inactive };
+    let active_1: string;
+    export { active_1 as active };
     export let icon: string;
     let content_3: string;
     export { content_3 as content };
@@ -168,9 +176,11 @@ export namespace gridLayout {
 }
 export const buttonReset: "focus:outline-none appearance-none cursor-pointer bg-transparent border-0 m-0 p-0 inline-block";
 export namespace expandable {
-    export let expandable: string;
-    export let expandableBox: string;
-    export let expandableBleed: string;
+    let wrapper_5: string;
+    export { wrapper_5 as wrapper };
+    export let box: string;
+    let bleed_1: string;
+    export { bleed_1 as bleed };
     export let chevron: string;
     export let chevronNonBox: string;
     export let chevronTransform: string;
@@ -240,8 +250,7 @@ export namespace button {
     export let negativeSmallLoading: string;
     export let negativeQuietLoading: string;
     export let negativeSmallQuietLoading: string;
-    let pill_1: string;
-    export { pill_1 as pill };
+    export let pill: string;
     export let pillSmall: string;
     export let pillLoading: string;
     export let pillSmallLoading: string;
@@ -254,8 +263,8 @@ export namespace button {
     export let contentWidth: string;
 }
 export namespace buttonGroup {
-    let wrapper_3: string;
-    export { wrapper_3 as wrapper };
+    let wrapper_6: string;
+    export { wrapper_6 as wrapper };
     export let raised: string;
     let vertical_1: string;
     export { vertical_1 as vertical };
@@ -263,8 +272,8 @@ export namespace buttonGroup {
     export let nonOutlinedHorizontal: string;
 }
 export namespace buttonGroupItem {
-    let wrapper_4: string;
-    export { wrapper_4 as wrapper };
+    let wrapper_7: string;
+    export { wrapper_7 as wrapper };
     export let outlined: string;
     export let outlinedVertical: string;
     export let outlinedHorizontal: string;
@@ -278,7 +287,8 @@ export namespace buttonGroupItem {
 }
 export namespace modal {
     export let backdrop: string;
-    export let modal: string;
+    let base_6: string;
+    export { base_6 as base };
     let content_4: string;
     export { content_4 as content };
     export let footer: string;
@@ -312,7 +322,8 @@ export namespace modalElement {
     export { footer_1 as footer };
 }
 export namespace alert {
-    export let alert: string;
+    let wrapper_8: string;
+    export { wrapper_8 as wrapper };
     export let willChangeHeight: string;
     export let textWrapper: string;
     let title_2: string;
@@ -333,10 +344,10 @@ export namespace alert {
     export let infoIcon: string;
 }
 export namespace input {
-    let wrapper_5: string;
-    export { wrapper_5 as wrapper };
-    let base_3: string;
-    export { base_3 as base };
+    let wrapper_9: string;
+    export { wrapper_9 as wrapper };
+    let base_7: string;
+    export { base_7 as base };
     let _default: string;
     export { _default as default };
     let disabled_1: string;
@@ -349,8 +360,8 @@ export namespace input {
     export let textArea: string;
 }
 export namespace select {
-    let base_4: string;
-    export { base_4 as base };
+    let base_8: string;
+    export { base_8 as base };
     let _default_1: string;
     export { _default_1 as default };
     let disabled_2: string;
@@ -359,44 +370,45 @@ export namespace select {
     export { invalid_1 as invalid };
     let readOnly_1: string;
     export { readOnly_1 as readOnly };
-    let wrapper_6: string;
-    export { wrapper_6 as wrapper };
+    let wrapper_10: string;
+    export { wrapper_10 as wrapper };
     export let selectWrapper: string;
     let chevron_1: string;
     export { chevron_1 as chevron };
     export let chevronDisabled: string;
 }
 export namespace label {
-    let label_2: string;
-    export { label_2 as label };
+    let base_9: string;
+    export { base_9 as base };
     export let optional: string;
 }
 export namespace helpText {
-    let helpText: string;
-    let helpTextColor: string;
-    let helpTextColorInvalid: string;
+    let base_10: string;
+    export { base_10 as base };
+    export let color: string;
+    export let colorInvalid: string;
 }
 export namespace suffix {
-    let wrapper_7: string;
-    export { wrapper_7 as wrapper };
+    let wrapper_11: string;
+    export { wrapper_11 as wrapper };
     export let wrapperWithLabel: string;
     export let wrapperWithIcon: string;
-    let label_3: string;
-    export { label_3 as label };
+    let label_2: string;
+    export { label_2 as label };
 }
 export namespace prefix {
-    let wrapper_8: string;
-    export { wrapper_8 as wrapper };
+    let wrapper_12: string;
+    export { wrapper_12 as wrapper };
     let wrapperWithLabel_1: string;
     export { wrapperWithLabel_1 as wrapperWithLabel };
     let wrapperWithIcon_1: string;
     export { wrapperWithIcon_1 as wrapperWithIcon };
-    let label_4: string;
-    export { label_4 as label };
+    let label_3: string;
+    export { label_3 as label };
 }
 export namespace breadcrumbs {
-    let wrapper_9: string;
-    export { wrapper_9 as wrapper };
+    let wrapper_13: string;
+    export { wrapper_13 as wrapper };
     export let text: string;
     let link_1: string;
     export { link_1 as link };
@@ -406,8 +418,8 @@ export namespace breadcrumbs {
 }
 export namespace toggle {
     export let field: string;
-    let wrapper_10: string;
-    export { wrapper_10 as wrapper };
+    let wrapper_14: string;
+    export { wrapper_14 as wrapper };
     export let wrapperRadioButtons: string;
     export let wrapperRadioButtonsJustified: string;
     export let radioButtonsGroup: string;
@@ -415,8 +427,8 @@ export namespace toggle {
     export let input: string;
     let a11y_5: string;
     export { a11y_5 as a11y };
-    let label_5: string;
-    export { label_5 as label };
+    let label_4: string;
+    export { label_4 as label };
     export let labelBefore: string;
     export let checkbox: string;
     export let checkboxInvalid: string;
@@ -432,8 +444,8 @@ export namespace toggle {
     export let radioButtonsSmall: string;
 }
 export namespace deadToggle {
-    let wrapper_11: string;
-    export { wrapper_11 as wrapper };
+    let wrapper_15: string;
+    export { wrapper_15 as wrapper };
     let input_1: string;
     export { input_1 as input };
     export let inputVue: string;
@@ -443,16 +455,16 @@ export namespace deadToggle {
 }
 export namespace clickable {
     export let toggle: string;
-    let label_6: string;
-    export { label_6 as label };
+    let label_5: string;
+    export { label_5 as label };
     export let buttonOrLink: string;
     export let buttonOrLinkStretch: string;
 }
 export namespace combobox {
-    let wrapper_12: string;
-    export { wrapper_12 as wrapper };
-    let base_5: string;
-    export { base_5 as base };
+    let wrapper_16: string;
+    export { wrapper_16 as wrapper };
+    let base_11: string;
+    export { base_11 as base };
     export let listbox: string;
     export let option: string;
     export let optionUnselected: string;
@@ -462,8 +474,8 @@ export namespace combobox {
     export { a11y_6 as a11y };
 }
 export namespace attention {
-    let base_6: string;
-    export { base_6 as base };
+    let base_12: string;
+    export { base_12 as base };
     export let tooltip: string;
     export let callout: string;
     export let highlight: string;
@@ -500,7 +512,7 @@ export namespace pagination {
     let a11y_7: string;
     export { a11y_7 as a11y };
     export let pages: string;
-    let active_1: string;
-    export { active_1 as active };
+    let active_2: string;
+    export { active_2 as active };
     export let notActive: string;
 }

--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -1,203 +1,83 @@
-export namespace pageIndicator {
+export namespace alert {
     let wrapper: string;
-    let dot: string;
-    let inactive: string;
-    let active: string;
+    let willChangeHeight: string;
+    let textWrapper: string;
+    let title: string;
+    let icon: string;
+    let negative: string;
+    let negativeIcon: string;
+    let positive: string;
+    let positiveIcon: string;
+    let warning: string;
+    let warningIcon: string;
+    let info: string;
+    let infoIcon: string;
+}
+export namespace attention {
+    let base: string;
+    let tooltip: string;
+    let callout: string;
+    let highlight: string;
+    let popover: string;
+    let arrowBase: string;
+    let arrowDirectionLeftStart: string;
+    let arrowDirectionLeft: string;
+    let arrowDirectionLeftEnd: string;
+    let arrowDirectionRightStart: string;
+    let arrowDirectionRight: string;
+    let arrowDirectionRightEnd: string;
+    let arrowDirectionBottomStart: string;
+    let arrowDirectionBottom: string;
+    let arrowDirectionBottomEnd: string;
+    let arrowDirectionTopStart: string;
+    let arrowDirectionTop: string;
+    let arrowDirectionTopEnd: string;
+    let arrowTooltip: string;
+    let arrowCallout: string;
+    let arrowPopover: string;
+    let arrowHighlight: string;
+    let content: string;
+    let notCallout: string;
+    let closeBtn: string;
 }
 export namespace badge {
-    let base: string;
-    let neutral: string;
-    let info: string;
-    let positive: string;
-    let warning: string;
-    let negative: string;
-    let disabled: string;
-    let price: string;
-    let sponsored: string;
-    let positionBase: string;
-    let positionTL: string;
-    let positionTR: string;
-    let positionBR: string;
-    let positionBL: string;
-}
-export namespace slider {
-    let wrapper_1: string;
-    export { wrapper_1 as wrapper };
-    export let track: string;
-    export let trackDisabled: string;
-    export let activeTrack: string;
-    export let activeTrackEnabled: string;
-    export let activeTrackDisabled: string;
-    export let thumb: string;
-    export let thumbEnabled: string;
-    export let thumbDisabled: string;
-}
-export namespace box {
     let base_1: string;
     export { base_1 as base };
-    export let bleed: string;
+    export let neutral: string;
     let info_1: string;
     export { info_1 as info };
-    let neutral_1: string;
-    export { neutral_1 as neutral };
-    export let bordered: string;
-}
-export namespace pill {
-    let wrapper_2: string;
-    export { wrapper_2 as wrapper };
-    export let button: string;
-    export let suggestion: string;
-    export let filter: string;
-    export let label: string;
-    export let labelWithoutClose: string;
-    export let labelWithClose: string;
-    export let close: string;
-    export let a11y: string;
-}
-export namespace step {
-    export let container: string;
-    export let vertical: string;
-    export let horizontal: string;
-    export let alignLeft: string;
-    export let alignRight: string;
-    let dot_1: string;
-    export { dot_1 as dot };
-    export let dotAlignRight: string;
-    export let dotHorizontal: string;
-    export let dotActive: string;
-    export let dotIncomplete: string;
-    export let line: string;
-    export let lineVertical: string;
-    export let lineAlignRight: string;
-    export let lineHorizontal: string;
-    export let lineHorizontalAlignRight: string;
-    export let lineHorizontalAlignLeft: string;
-    export let lineIncomplete: string;
-    export let lineComplete: string;
-    export let content: string;
-    export let contentVertical: string;
-    export let contentHorizontal: string;
-}
-export namespace steps {
-    let container_1: string;
-    export { container_1 as container };
-    let horizontal_1: string;
-    export { horizontal_1 as horizontal };
-}
-export namespace card {
-    let base_2: string;
-    export { base_2 as base };
-    export let shadow: string;
-    export let selected: string;
-    export let outline: string;
-    export let outlineUnselected: string;
-    export let outlineSelected: string;
-    export let flat: string;
-    export let flatUnselected: string;
-    export let flatSelected: string;
-    let a11y_1: string;
-    export { a11y_1 as a11y };
-}
-export namespace switchToggle {
-    let label_1: string;
-    export { label_1 as label };
-    export let labelDisabled: string;
-    let track_1: string;
-    export { track_1 as track };
-    export let trackActive: string;
-    export let trackInactive: string;
-    let trackDisabled_1: string;
-    export { trackDisabled_1 as trackDisabled };
-    export let handle: string;
-    export let handleSelected: string;
-    export let handleNotDisabled: string;
-    export let handleDisabled: string;
-    let a11y_2: string;
-    export { a11y_2 as a11y };
-}
-export namespace toaster {
-    let container_2: string;
-    export { container_2 as container };
-    let base_3: string;
-    export { base_3 as base };
-    let content_1: string;
-    export { content_1 as content };
-}
-export namespace toast {
-    let wrapper_3: string;
-    export { wrapper_3 as wrapper };
-    let base_4: string;
-    export { base_4 as base };
     let positive_1: string;
     export { positive_1 as positive };
     let warning_1: string;
     export { warning_1 as warning };
     let negative_1: string;
     export { negative_1 as negative };
-    export let iconBase: string;
-    export let iconPositive: string;
-    export let iconWarning: string;
-    export let iconNegative: string;
-    export let iconLoading: string;
-    let content_2: string;
-    export { content_2 as content };
-    let close_1: string;
-    export { close_1 as close };
+    export let disabled: string;
+    export let price: string;
+    export let sponsored: string;
+    export let positionBase: string;
+    export let positionTL: string;
+    export let positionTR: string;
+    export let positionBR: string;
+    export let positionBL: string;
 }
-export namespace tabs {
-    let wrapper_4: string;
-    export { wrapper_4 as wrapper };
-    let container_3: string;
-    export { container_3 as container };
-    export let selectionIndicator: string;
+export namespace box {
+    let base_2: string;
+    export { base_2 as base };
+    export let bleed: string;
+    let info_2: string;
+    export { info_2 as info };
+    let neutral_1: string;
+    export { neutral_1 as neutral };
+    export let bordered: string;
 }
-export namespace tab {
-    let base_5: string;
-    export { base_5 as base };
-    let inactive_1: string;
-    export { inactive_1 as inactive };
-    let active_1: string;
-    export { active_1 as active };
-    export let icon: string;
-    let content_3: string;
-    export { content_3 as content };
-    export let contentUnderlined: string;
-}
-export namespace gridLayout {
-    let cols1: string;
-    let cols2: string;
-    let cols3: string;
-    let cols4: string;
-    let cols5: string;
-    let cols6: string;
-    let cols7: string;
-    let cols8: string;
-    let cols9: string;
-}
-export const buttonReset: "focus:outline-none appearance-none cursor-pointer bg-transparent border-0 m-0 p-0 inline-block";
-export namespace expandable {
-    let wrapper_5: string;
-    export { wrapper_5 as wrapper };
-    export let box: string;
-    let bleed_1: string;
-    export { bleed_1 as bleed };
-    export let chevron: string;
-    export let chevronNonBox: string;
-    export let chevronTransform: string;
-    export let chevronExpand: string;
-    export let chevronCollapse: string;
-    export let elementsChevronDownTransform: string;
-    export let elementsChevronUpTransform: string;
-    export let elementsChevronExpand: string;
-    export let elementsChevronCollapse: string;
-    export let expansion: string;
-    export let expansionNotExpanded: string;
-    let button_1: string;
-    export { button_1 as button };
-    export let buttonBox: string;
-    export let contentWithTitle: string;
-    export let title: string;
-    export let titleType: string;
+export namespace breadcrumbs {
+    let wrapper_1: string;
+    export { wrapper_1 as wrapper };
+    export let text: string;
+    export let link: string;
+    export let separator: string;
+    export let a11y: string;
 }
 export namespace button {
     export let secondary: string;
@@ -254,26 +134,26 @@ export namespace button {
     export let pillSmall: string;
     export let pillLoading: string;
     export let pillSmallLoading: string;
-    export let link: string;
+    let link_1: string;
+    export { link_1 as link };
     export let linkSmall: string;
     export let linkAsButton: string;
-    let a11y_3: string;
-    export { a11y_3 as a11y };
+    let a11y_1: string;
+    export { a11y_1 as a11y };
     export let fullWidth: string;
     export let contentWidth: string;
 }
 export namespace buttonGroup {
-    let wrapper_6: string;
-    export { wrapper_6 as wrapper };
+    let wrapper_2: string;
+    export { wrapper_2 as wrapper };
     export let raised: string;
-    let vertical_1: string;
-    export { vertical_1 as vertical };
+    export let vertical: string;
     export let nonOutlinedVertical: string;
     export let nonOutlinedHorizontal: string;
 }
 export namespace buttonGroupItem {
-    let wrapper_7: string;
-    export { wrapper_7 as wrapper };
+    let wrapper_3: string;
+    export { wrapper_3 as wrapper };
     export let outlined: string;
     export let outlinedVertical: string;
     export let outlinedHorizontal: string;
@@ -282,21 +162,117 @@ export namespace buttonGroupItem {
     export let outlinedUnselected: string;
     export let outlinedSelected: string;
     export let unSelected: string;
+    export let selected: string;
+}
+export const buttonReset: "focus:outline-none appearance-none cursor-pointer bg-transparent border-0 m-0 p-0 inline-block";
+export namespace card {
+    let base_3: string;
+    export { base_3 as base };
+    export let shadow: string;
     let selected_1: string;
     export { selected_1 as selected };
+    export let outline: string;
+    export let outlineUnselected: string;
+    export let outlineSelected: string;
+    export let flat: string;
+    export let flatUnselected: string;
+    export let flatSelected: string;
+    let a11y_2: string;
+    export { a11y_2 as a11y };
+}
+export namespace clickable {
+    let toggle: string;
+    let label: string;
+    let buttonOrLink: string;
+    let buttonOrLinkStretch: string;
+}
+export namespace combobox {
+    let wrapper_4: string;
+    export { wrapper_4 as wrapper };
+    let base_4: string;
+    export { base_4 as base };
+    export let listbox: string;
+    export let option: string;
+    export let optionUnselected: string;
+    export let optionSelected: string;
+    export let textMatch: string;
+    let a11y_3: string;
+    export { a11y_3 as a11y };
+}
+export namespace expandable {
+    let wrapper_5: string;
+    export { wrapper_5 as wrapper };
+    export let box: string;
+    let bleed_1: string;
+    export { bleed_1 as bleed };
+    export let chevron: string;
+    export let chevronNonBox: string;
+    export let chevronTransform: string;
+    export let chevronExpand: string;
+    export let chevronCollapse: string;
+    export let elementsChevronDownTransform: string;
+    export let elementsChevronUpTransform: string;
+    export let elementsChevronExpand: string;
+    export let elementsChevronCollapse: string;
+    export let expansion: string;
+    export let expansionNotExpanded: string;
+    export let button: string;
+    export let buttonBox: string;
+    export let contentWithTitle: string;
+    let title_1: string;
+    export { title_1 as title };
+    export let titleType: string;
+}
+export namespace gridLayout {
+    let cols1: string;
+    let cols2: string;
+    let cols3: string;
+    let cols4: string;
+    let cols5: string;
+    let cols6: string;
+    let cols7: string;
+    let cols8: string;
+    let cols9: string;
+}
+export namespace helpText {
+    let base_5: string;
+    export { base_5 as base };
+    export let color: string;
+    export let colorInvalid: string;
+}
+export namespace input {
+    let wrapper_6: string;
+    export { wrapper_6 as wrapper };
+    let base_6: string;
+    export { base_6 as base };
+    let _default: string;
+    export { _default as default };
+    let disabled_1: string;
+    export { disabled_1 as disabled };
+    export let invalid: string;
+    export let readOnly: string;
+    export let placeholder: string;
+    export let suffix: string;
+    export let prefix: string;
+    export let textArea: string;
+}
+export namespace label {
+    let base_7: string;
+    export { base_7 as base };
+    export let optional: string;
 }
 export namespace modal {
     export let backdrop: string;
-    let base_6: string;
-    export { base_6 as base };
-    let content_4: string;
-    export { content_4 as content };
+    let base_8: string;
+    export { base_8 as base };
+    let content_1: string;
+    export { content_1 as content };
     export let footer: string;
     export let transitionTitle: string;
     export let transitionTitleCenter: string;
     export let transitionTitleColSpan: string;
-    let title_1: string;
-    export { title_1 as title };
+    let title_2: string;
+    export { title_2 as title };
     export let titleText: string;
     export let titleButton: string;
     export let titleButtonLeft: string;
@@ -321,47 +297,53 @@ export namespace modalElement {
     let footer_1: string;
     export { footer_1 as footer };
 }
-export namespace alert {
-    let wrapper_8: string;
-    export { wrapper_8 as wrapper };
-    export let willChangeHeight: string;
-    export let textWrapper: string;
-    let title_2: string;
-    export { title_2 as title };
+export namespace pageIndicator {
+    let wrapper_7: string;
+    export { wrapper_7 as wrapper };
+    export let dot: string;
+    export let inactive: string;
+    export let active: string;
+}
+export namespace pagination {
+    let link_2: string;
+    export { link_2 as link };
+    export let currentPage: string;
     let icon_1: string;
     export { icon_1 as icon };
-    let negative_3: string;
-    export { negative_3 as negative };
-    export let negativeIcon: string;
-    let positive_2: string;
-    export { positive_2 as positive };
-    export let positiveIcon: string;
-    let warning_2: string;
-    export { warning_2 as warning };
-    export let warningIcon: string;
-    let info_2: string;
-    export { info_2 as info };
-    export let infoIcon: string;
+    export let containerNav: string;
+    let a11y_4: string;
+    export { a11y_4 as a11y };
+    export let pages: string;
+    let active_1: string;
+    export { active_1 as active };
+    export let notActive: string;
 }
-export namespace input {
+export namespace pill {
+    let wrapper_8: string;
+    export { wrapper_8 as wrapper };
+    let button_1: string;
+    export { button_1 as button };
+    export let suggestion: string;
+    export let filter: string;
+    let label_1: string;
+    export { label_1 as label };
+    export let labelWithoutClose: string;
+    export let labelWithClose: string;
+    export let close: string;
+    let a11y_5: string;
+    export { a11y_5 as a11y };
+}
+export namespace prefix {
     let wrapper_9: string;
     export { wrapper_9 as wrapper };
-    let base_7: string;
-    export { base_7 as base };
-    let _default: string;
-    export { _default as default };
-    let disabled_1: string;
-    export { disabled_1 as disabled };
-    export let invalid: string;
-    export let readOnly: string;
-    export let placeholder: string;
-    export let suffix: string;
-    export let prefix: string;
-    export let textArea: string;
+    export let wrapperWithLabel: string;
+    export let wrapperWithIcon: string;
+    let label_2: string;
+    export { label_2 as label };
 }
 export namespace select {
-    let base_8: string;
-    export { base_8 as base };
+    let base_9: string;
+    export { base_9 as base };
     let _default_1: string;
     export { _default_1 as default };
     let disabled_2: string;
@@ -377,26 +359,51 @@ export namespace select {
     export { chevron_1 as chevron };
     export let chevronDisabled: string;
 }
-export namespace label {
-    let base_9: string;
-    export { base_9 as base };
-    export let optional: string;
-}
-export namespace helpText {
-    let base_10: string;
-    export { base_10 as base };
-    export let color: string;
-    export let colorInvalid: string;
-}
-export namespace suffix {
+export namespace slider {
     let wrapper_11: string;
     export { wrapper_11 as wrapper };
-    export let wrapperWithLabel: string;
-    export let wrapperWithIcon: string;
-    let label_2: string;
-    export { label_2 as label };
+    export let track: string;
+    export let trackDisabled: string;
+    export let activeTrack: string;
+    export let activeTrackEnabled: string;
+    export let activeTrackDisabled: string;
+    export let thumb: string;
+    export let thumbEnabled: string;
+    export let thumbDisabled: string;
 }
-export namespace prefix {
+export namespace step {
+    export let container: string;
+    let vertical_1: string;
+    export { vertical_1 as vertical };
+    export let horizontal: string;
+    export let alignLeft: string;
+    export let alignRight: string;
+    let dot_1: string;
+    export { dot_1 as dot };
+    export let dotAlignRight: string;
+    export let dotHorizontal: string;
+    export let dotActive: string;
+    export let dotIncomplete: string;
+    export let line: string;
+    export let lineVertical: string;
+    export let lineAlignRight: string;
+    export let lineHorizontal: string;
+    export let lineHorizontalAlignRight: string;
+    export let lineHorizontalAlignLeft: string;
+    export let lineIncomplete: string;
+    export let lineComplete: string;
+    let content_2: string;
+    export { content_2 as content };
+    export let contentVertical: string;
+    export let contentHorizontal: string;
+}
+export namespace steps {
+    let container_1: string;
+    export { container_1 as container };
+    let horizontal_1: string;
+    export { horizontal_1 as horizontal };
+}
+export namespace suffix {
     let wrapper_12: string;
     export { wrapper_12 as wrapper };
     let wrapperWithLabel_1: string;
@@ -406,29 +413,85 @@ export namespace prefix {
     let label_3: string;
     export { label_3 as label };
 }
-export namespace breadcrumbs {
+export namespace tab {
+    let base_10: string;
+    export { base_10 as base };
+    let inactive_1: string;
+    export { inactive_1 as inactive };
+    let active_2: string;
+    export { active_2 as active };
+    let icon_2: string;
+    export { icon_2 as icon };
+    let content_3: string;
+    export { content_3 as content };
+    export let contentUnderlined: string;
+}
+export namespace tabs {
     let wrapper_13: string;
     export { wrapper_13 as wrapper };
-    export let text: string;
-    let link_1: string;
-    export { link_1 as link };
-    export let separator: string;
-    let a11y_4: string;
-    export { a11y_4 as a11y };
+    let container_2: string;
+    export { container_2 as container };
+    export let selectionIndicator: string;
+}
+export namespace toast {
+    let wrapper_14: string;
+    export { wrapper_14 as wrapper };
+    let base_11: string;
+    export { base_11 as base };
+    let positive_2: string;
+    export { positive_2 as positive };
+    let warning_2: string;
+    export { warning_2 as warning };
+    let negative_3: string;
+    export { negative_3 as negative };
+    export let iconBase: string;
+    export let iconPositive: string;
+    export let iconWarning: string;
+    export let iconNegative: string;
+    export let iconLoading: string;
+    let content_4: string;
+    export { content_4 as content };
+    let close_1: string;
+    export { close_1 as close };
+}
+export namespace toaster {
+    let container_3: string;
+    export { container_3 as container };
+    let base_12: string;
+    export { base_12 as base };
+    let content_5: string;
+    export { content_5 as content };
+}
+export namespace switchToggle {
+    let label_4: string;
+    export { label_4 as label };
+    export let labelDisabled: string;
+    let track_1: string;
+    export { track_1 as track };
+    export let trackActive: string;
+    export let trackInactive: string;
+    let trackDisabled_1: string;
+    export { trackDisabled_1 as trackDisabled };
+    export let handle: string;
+    export let handleSelected: string;
+    export let handleNotDisabled: string;
+    export let handleDisabled: string;
+    let a11y_6: string;
+    export { a11y_6 as a11y };
 }
 export namespace toggle {
     export let field: string;
-    let wrapper_14: string;
-    export { wrapper_14 as wrapper };
+    let wrapper_15: string;
+    export { wrapper_15 as wrapper };
     export let wrapperRadioButtons: string;
     export let wrapperRadioButtonsJustified: string;
     export let radioButtonsGroup: string;
     export let radioButtonsGroupJustified: string;
     export let input: string;
-    let a11y_5: string;
-    export { a11y_5 as a11y };
-    let label_4: string;
-    export { label_4 as label };
+    let a11y_7: string;
+    export { a11y_7 as a11y };
+    let label_5: string;
+    export { label_5 as label };
     export let labelBefore: string;
     export let checkbox: string;
     export let checkboxInvalid: string;
@@ -444,75 +507,12 @@ export namespace toggle {
     export let radioButtonsSmall: string;
 }
 export namespace deadToggle {
-    let wrapper_15: string;
-    export { wrapper_15 as wrapper };
+    let wrapper_16: string;
+    export { wrapper_16 as wrapper };
     let input_1: string;
     export { input_1 as input };
     export let inputVue: string;
+    export let labelVue: string;
     export let labelRadio: string;
     export let labelCheckbox: string;
-    export let labelVue: string;
-}
-export namespace clickable {
-    export let toggle: string;
-    let label_5: string;
-    export { label_5 as label };
-    export let buttonOrLink: string;
-    export let buttonOrLinkStretch: string;
-}
-export namespace combobox {
-    let wrapper_16: string;
-    export { wrapper_16 as wrapper };
-    let base_11: string;
-    export { base_11 as base };
-    export let listbox: string;
-    export let option: string;
-    export let optionUnselected: string;
-    export let optionSelected: string;
-    export let textMatch: string;
-    let a11y_6: string;
-    export { a11y_6 as a11y };
-}
-export namespace attention {
-    let base_12: string;
-    export { base_12 as base };
-    export let tooltip: string;
-    export let callout: string;
-    export let highlight: string;
-    export let popover: string;
-    export let arrowBase: string;
-    export let arrowDirectionLeftStart: string;
-    export let arrowDirectionLeft: string;
-    export let arrowDirectionLeftEnd: string;
-    export let arrowDirectionRightStart: string;
-    export let arrowDirectionRight: string;
-    export let arrowDirectionRightEnd: string;
-    export let arrowDirectionBottomStart: string;
-    export let arrowDirectionBottom: string;
-    export let arrowDirectionBottomEnd: string;
-    export let arrowDirectionTopStart: string;
-    export let arrowDirectionTop: string;
-    export let arrowDirectionTopEnd: string;
-    export let arrowTooltip: string;
-    export let arrowCallout: string;
-    export let arrowPopover: string;
-    export let arrowHighlight: string;
-    let content_5: string;
-    export { content_5 as content };
-    export let notCallout: string;
-    export let closeBtn: string;
-}
-export namespace pagination {
-    let link_2: string;
-    export { link_2 as link };
-    export let currentPage: string;
-    let icon_2: string;
-    export { icon_2 as icon };
-    export let containerNav: string;
-    let a11y_7: string;
-    export { a11y_7 as a11y };
-    export let pages: string;
-    let active_2: string;
-    export { active_2 as active };
-    export let notActive: string;
 }

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -515,7 +515,7 @@ export const deadToggle = {
 
 export const clickable = {
   toggle: 'absolute inset-0 h-full w-full appearance-none cursor-pointer focusable focusable-inset',
-  label: `px-12 ${label.label} py-8! cursor-pointer focusable focusable-inset`,
+  label: `px-12 ${label.base} py-8! cursor-pointer focusable focusable-inset`,
   buttonOrLink: 'bg-transparent focusable',
   buttonOrLinkStretch: 'inset-0 absolute',
 };

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -36,7 +36,7 @@ export const slider = {
 };
 
 export const box = {
-  box: 'group block relative break-words last-child:mb-0 p-16 rounded-8', // Relative here enables w-clickable
+  base: 'group block relative break-words last-child:mb-0 p-16 rounded-8', // Relative here enables w-clickable
   bleed: '-mx-16 sm:mx-0 rounded-l-0 rounded-r-0 sm:rounded-8', // We target L and R to override the default rounded-8
   info: 's-bg-info-subtle',
   neutral: 's-surface-sunken',
@@ -44,7 +44,7 @@ export const box = {
 };
 
 export const pill = {
-  pill: 'flex items-center',
+  wrapper: 'flex items-center',
   button: 'inline-flex items-center focusable text-xs transition-all',
   suggestion:
     'bg-[--w-color-pill-suggestion-background] hover:bg-[--w-color-pill-suggestion-background-hover] active:bg-[--w-color-pill-suggestion-background-active] s-text font-bold',
@@ -120,8 +120,8 @@ export const switchToggle = {
 
 export const toaster = {
   container: 'fixed transform translate-z-0 bottom-16 left-0 right-0 mx-8 sm:mx-16 z-50 pointer-events-none',
+  base: 'grid auto-rows-auto justify-items-center justify-center mx-auto pointer-events-none',
   content: 'w-full',
-  toaster: 'grid auto-rows-auto justify-items-center justify-center mx-auto pointer-events-none',
 };
 
 export const toast = {
@@ -140,15 +140,15 @@ export const toast = {
 };
 
 export const tabs = {
-  tabContainer: 'inline-grid relative -mb-1',
-  wunderbar: 'absolute s-border-selected -bottom-0 border-b-4 transition-all',
-  wrapperUnderlined: 'inline-block border-b s-border mb-32',
+  wrapper: 'inline-block border-b s-border mb-32',
+  container: 'inline-grid relative -mb-1',
+  selectionIndicator: 'absolute s-border-selected -bottom-0 border-b-4 transition-all',
 };
 
 export const tab = {
-  tab: 'grid items-center font-bold gap-8 focusable antialias p-16 pb-8 border-b-4 bg-transparent border-transparent hover:s-text-link hover:s-border-primary',
-  tabInactive: 's-text-subtle',
-  tabActive: 's-text-link',
+  base: 'grid items-center font-bold gap-8 focusable antialias p-16 pb-8 border-b-4 bg-transparent border-transparent hover:s-text-link hover:s-border-primary',
+  inactive: 's-text-subtle',
+  active: 's-text-link',
   icon: 'mx-auto',
   content: 'flex items-center justify-center gap-8',
   contentUnderlined: 'content-underlined', // content-underlined is a no-op that prevents a quirk in how Vue handles class bindings
@@ -170,10 +170,9 @@ export const gridLayout = {
 export const buttonReset = 'focus:outline-none appearance-none cursor-pointer bg-transparent border-0 m-0 p-0 inline-block';
 
 export const expandable = {
-  expandable: 'will-change-height s-text',
-  expandableBox:
-    's-surface-sunken hover:s-bg-hover active:s-bg-active py-0 px-0 group block relative break-words last-child:mb-0 rounded-8',
-  expandableBleed: '-mx-16 rounded-l-0 rounded-r-0 sm:mx-0 sm:rounded-8',
+  wrapper: 'will-change-height s-text',
+  box: 's-surface-sunken hover:s-bg-hover active:s-bg-active py-0 px-0 group block relative break-words last-child:mb-0 rounded-8',
+  bleed: '-mx-16 rounded-l-0 rounded-r-0 sm:mx-0 sm:rounded-8',
   chevron: 'inline-block align-middle s-icon',
   chevronNonBox: 'ml-8',
   chevronTransform: 'transform transition-transform transform-gpu ease-in-out',
@@ -341,8 +340,7 @@ export const buttonGroupItem = {
 export const modal = {
   backdrop:
     'fixed inset-0 flex sm:place-content-center sm:place-items-center items-end z-30 [--w-modal-max-height:80%] [--w-modal-width:640px] bg-[--w-black/25]',
-  modal:
-    'pb-safe-[32] shadow-m max-h-[--w-modal-max-height] min-h-[--w-modal-min-height] w-[--w-modal-width] h-[--w-modal-height] relative transition-300 ease-in-out backface-hidden will-change-height rounded-8 mx-0 sm:mx-16 bg-[--w-s-color-surface-elevated-100] flex flex-col overflow-hidden outline-none space-y-16 pt-8 sm:pt-32 sm:pb-32 rounded-b-0 sm:rounded-b-8',
+  base: 'pb-safe-[32] shadow-m max-h-[--w-modal-max-height] min-h-[--w-modal-min-height] w-[--w-modal-width] h-[--w-modal-height] relative transition-300 ease-in-out backface-hidden will-change-height rounded-8 mx-0 sm:mx-16 bg-[--w-s-color-surface-elevated-100] flex flex-col overflow-hidden outline-none space-y-16 pt-8 sm:pt-32 sm:pb-32 rounded-b-0 sm:rounded-b-8',
   content: 'block overflow-y-auto overflow-x-hidden last-child:mb-0 grow shrink px-16 sm:px-32 relative',
   footer: 'flex justify-end shrink-0 px-16 sm:px-32',
   transitionTitle: 'transition-all duration-300',
@@ -382,7 +380,7 @@ export const modalElement = {
 };
 
 export const alert = {
-  alert: 'flex p-16 border border-l-4 rounded-4 s-text',
+  wrapper: 'flex p-16 border border-l-4 rounded-4 s-text',
   willChangeHeight: 'will-change-height',
   textWrapper: 'last-child:mb-0 text-s',
   title: 'text-s',
@@ -428,28 +426,28 @@ export const select = {
 };
 
 export const label = {
-  label: 'antialiased block relative text-s font-bold pb-4 cursor-pointer s-text',
+  base: 'antialiased block relative text-s font-bold pb-4 cursor-pointer s-text',
   optional: 'pl-8 font-normal text-s s-text-subtle',
 };
 
 export const helpText = {
-  helpText: 'text-xs mt-4 block',
-  helpTextColor: 's-text-subtle',
-  helpTextColorInvalid: 's-text-negative',
+  base: 'text-xs mt-4 block',
+  color: 's-text-subtle',
+  colorInvalid: 's-text-negative',
 };
 
-const prefixSuffixWrapperBase =
+const prefixSuffixWrapper =
   'absolute top-0 bottom-0 flex justify-center items-center focusable rounded-4 focus:[--w-outline-offset:-2px] bg-transparent ';
 
 export const suffix = {
-  wrapper: prefixSuffixWrapperBase + 'right-0',
+  wrapper: prefixSuffixWrapper + 'right-0',
   wrapperWithLabel: 'w-max pr-12',
   wrapperWithIcon: 'w-40',
   label: 'antialiased block relative cursor-default pb-0 font-bold text-xs s-text',
 };
 
 export const prefix = {
-  wrapper: prefixSuffixWrapperBase + 'left-0',
+  wrapper: prefixSuffixWrapper + 'left-0',
   wrapperWithLabel: 'w-max pl-12',
   wrapperWithIcon: 'w-40',
   label: 'antialiased block relative cursor-default pb-0 font-bold text-xs s-text',
@@ -540,6 +538,7 @@ export const attention = {
   highlight: 'bg-[--w-color-callout-background] border-[--w-color-callout-border] s-text py-8 px-16 rounded-8 drop-shadow-m translate-z-0',
   popover:
     'bg-[--w-s-color-surface-elevated-300] border-[--w-s-color-surface-elevated-300] s-text rounded-8 p-16 drop-shadow-m translate-z-0',
+
   arrowBase: 'absolute h-[14px] w-[14px] border-2 border-b-0 border-r-0 rounded-tl-4 transform',
   arrowDirectionLeftStart: '-left-[8px]',
   arrowDirectionLeft: '-left-[8px]',
@@ -557,6 +556,7 @@ export const attention = {
   arrowCallout: 'bg-[--w-color-callout-background] border-[--w-color-callout-border]',
   arrowPopover: 'bg-[--w-s-color-surface-elevated-300] border-[--w-s-color-surface-elevated-300]',
   arrowHighlight: 'bg-[--w-color-callout-background] border-[--w-color-callout-border]',
+
   content: 'last-child:mb-0',
   notCallout: 'absolute z-50',
   closeBtn: `${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill} justify-self-end -mr-8 ml-8`,

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -52,7 +52,6 @@ const buttonVariants = {
 const prefixSuffixWrapper =
   'absolute top-0 bottom-0 flex justify-center items-center focusable rounded-4 focus:[--w-outline-offset:-2px] bg-transparent ';
 
-  
 export const alert = {
   wrapper: 'flex p-16 border border-l-4 rounded-4 s-text',
   willChangeHeight: 'will-change-height',
@@ -507,7 +506,6 @@ export const toaster = {
   base: 'grid auto-rows-auto justify-items-center justify-center mx-auto pointer-events-none',
   content: 'w-full',
 };
-
 
 // TOGGLE COMPONENTS:
 export const switchToggle = {

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -1,203 +1,3 @@
-export const pageIndicator = {
-  wrapper: 'flex space-x-8 p-8',
-  dot: 'h-8 w-8 rounded-full',
-  inactive: 's-bg-disabled-subtle hover:bg-[--w-s-icon-subtle]',
-  active: 'bg-[--w-s-icon-selected]',
-};
-
-export const badge = {
-  base: 'py-4 px-8 border-0 rounded-4 text-xs inline-flex',
-  neutral: 'bg-[--w-color-badge-neutral-background] s-text',
-  info: 'bg-[--w-color-badge-info-background] s-text',
-  positive: 'bg-[--w-color-badge-positive-background] s-text',
-  warning: 'bg-[--w-color-badge-warning-background] s-text',
-  negative: 'bg-[--w-color-badge-negative-background] s-text',
-  disabled: 's-bg-disabled s-text',
-  price: 'bg-[--w-black/70] s-text-inverted-static',
-  sponsored: 'bg-[--w-color-badge-sponsored-background] s-text',
-  positionBase: 'absolute backdrop-blur',
-  positionTL: 'rounded-tl-0 rounded-tr-0 rounded-bl-0 top-0 left-0',
-  positionTR: 'rounded-tl-0 rounded-tr-0 rounded-br-0 top-0 right-0',
-  positionBR: 'rounded-tr-0 rounded-br-0 rounded-bl-0 bottom-0 right-0',
-  positionBL: 'rounded-tl-0 rounded-br-0 rounded-bl-0 bottom-0 left-0',
-};
-
-export const slider = {
-  wrapper: 'touch-pan-y relative w-full h-44 py-2',
-  track: 'absolute s-bg-disabled-subtle h-4 top-20 rounded-4 w-full',
-  trackDisabled: 'pointer-events-none',
-  activeTrack: 'absolute h-6 top-[19px] rounded-4',
-  activeTrackEnabled: 's-bg-primary',
-  activeTrackDisabled: 's-bg-disabled pointer-events-none',
-  thumb: 'absolute transition-shadow w-24 h-24 bottom-10 rounded-4 outline-none',
-  thumbEnabled:
-    'border-2 shadow-[--w-shadow-slider] cursor-pointer s-bg-primary s-border-primary hover:s-bg-primary-hover hover:s-border-primary-hover hover:shadow-[--w-shadow-slider-handle-hover] active:s-bg-primary-active active:s-border-primary-active active:shadow-[--w-shadow-slider-handle-active] focus:shadow-[--w-shadow-slider-handle-hover] focus:s-border-primary-hover focus:s-bg-primary-hover',
-  thumbDisabled: 's-bg-disabled cursor-disabled pointer-events-none',
-};
-
-export const box = {
-  base: 'group block relative break-words last-child:mb-0 p-16 rounded-8', // Relative here enables w-clickable
-  bleed: '-mx-16 sm:mx-0 rounded-l-0 rounded-r-0 sm:rounded-8', // We target L and R to override the default rounded-8
-  info: 's-bg-info-subtle',
-  neutral: 's-surface-sunken',
-  bordered: 'border-2 s-border s-bg',
-};
-
-export const pill = {
-  wrapper: 'flex items-center',
-  button: 'inline-flex items-center focusable text-xs transition-all',
-  suggestion:
-    'bg-[--w-color-pill-suggestion-background] hover:bg-[--w-color-pill-suggestion-background-hover] active:bg-[--w-color-pill-suggestion-background-active] s-text font-bold',
-  filter: 's-bg-primary hover:s-bg-primary-hover active:s-bg-primary-active s-text-inverted',
-  label: 'pl-12 py-8 rounded-l-full',
-  labelWithoutClose: 'pr-12 rounded-r-full',
-  labelWithClose: 'pr-2',
-  close: 'pr-12 pl-4 py-8 rounded-r-full',
-  a11y: 'sr-only',
-};
-
-export const step = {
-  container: 'group/step',
-  vertical: 'group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16',
-  horizontal: 'group/steph grid-rows-[auto_20px] grid-cols-[1fr_20px_1fr] flex-1 grid gap-y-16 items-center',
-
-  alignLeft: 'grid-cols-[20px_1fr]',
-  alignRight: 'grid-cols-[1fr_20px] text-right',
-
-  dot: 'rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted',
-  dotAlignRight: 'col-start-2',
-  dotHorizontal: 'row-start-2 justify-self-end',
-  dotActive: 's-border-primary s-bg-primary',
-  dotIncomplete: 's-border s-bg',
-
-  line: 'group-last/stepv:hidden transition-colors duration-300',
-  lineVertical: 'w-2 h-full justify-self-center',
-  lineAlignRight: 'col-start-2',
-  lineHorizontal: 'h-2 w-full row-start-2',
-  lineHorizontalAlignRight: 'group-last/steph:bg-transparent',
-  lineHorizontalAlignLeft: 'group-first/steph:bg-transparent',
-
-  lineIncomplete: 's-bg-disabled',
-  lineComplete: 's-bg-primary',
-
-  content: 'last:mb-0 group-last/step:last:pb-0',
-  contentVertical: 'row-span-2 pb-32',
-  contentHorizontal: 'col-span-3 px-16 row-start-1 text-center',
-};
-
-export const steps = {
-  container: 'w-full',
-  horizontal: 'flex',
-};
-
-export const card = {
-  base: 'cursor-pointer overflow-hidden relative transition-all',
-  shadow: 'group rounded-8 s-surface-elevated-200 hover:s-surface-elevated-200-hover active:s-surface-elevated-200-active',
-  selected: '!s-bg-selected !hover:s-bg-selected-hover !active:s-bg-selected-active',
-  outline: 'absolute border-2 rounded-8 inset-0 transition-all',
-  outlineUnselected: 'border-transparent group-active:s-border-active',
-  outlineSelected: 's-border-selected group-hover:s-border-selected-hover group-active:s-border-selected-active',
-  flat: 'border-2 rounded-4',
-  flatUnselected: 's-bg hover:s-bg-hover active:s-bg-active s-border hover:s-border-hover active:s-border-active',
-  flatSelected:
-    's-bg-selected hover:s-bg-selected-hover active:s-bg-selected-active s-border-selected hover:s-border-selected-hover active:s-border-selected-active',
-  a11y: 'sr-only',
-};
-
-export const switchToggle = {
-  label: 'block relative h-24 w-44 cursor-pointer group',
-  labelDisabled: 'pointer-events-none',
-  track: 'absolute top-0 left-0 h-full w-full rounded-full transition-colors',
-  trackActive: 's-bg-primary group-hover:s-bg-primary-hover',
-  trackInactive: 'bg-[--w-color-switch-track-background] group-hover:bg-[--w-color-switch-track-background-hover]',
-  trackDisabled: 's-bg-disabled-subtle',
-  handle: 'absolute transform-gpu h-16 w-16 top-4 left-4 rounded-full transition-transform',
-  handleSelected: 'translate-x-20',
-  handleNotDisabled: 's-bg shadow-s',
-  handleDisabled: 's-bg-disabled',
-  a11y: 'sr-only',
-};
-
-export const toaster = {
-  container: 'fixed transform translate-z-0 bottom-16 left-0 right-0 mx-8 sm:mx-16 z-50 pointer-events-none',
-  base: 'grid auto-rows-auto justify-items-center justify-center mx-auto pointer-events-none',
-  content: 'w-full',
-};
-
-export const toast = {
-  wrapper: 'relative overflow-hidden w-full',
-  base: 'flex group p-8 mt-16 rounded-8 border-2 pointer-events-auto transition-all',
-  positive: 's-bg-positive-subtle s-border-positive-subtle s-text',
-  warning: 's-bg-warning-subtle s-border-warning-subtle s-text',
-  negative: 's-bg-negative-subtle s-border-negative-subtle s-text',
-  iconBase: 'shrink-0 rounded-full w-[16px] h-[16px] m-[8px]',
-  iconPositive: 's-icon-positive',
-  iconWarning: 's-icon-warning',
-  iconNegative: 's-icon-negative',
-  iconLoading: 'animate-bounce',
-  content: 'self-center mr-8 py-4 last-child:mb-0',
-  close: 'bg-transparent ml-auto p-[8px] s-icon hover:s-icon-hover active:s-icon-active',
-};
-
-export const tabs = {
-  wrapper: 'inline-block border-b s-border mb-32',
-  container: 'inline-grid relative -mb-1',
-  selectionIndicator: 'absolute s-border-selected -bottom-0 border-b-4 transition-all',
-};
-
-export const tab = {
-  base: 'grid items-center font-bold gap-8 focusable antialias p-16 pb-8 border-b-4 bg-transparent border-transparent hover:s-text-link hover:s-border-primary',
-  inactive: 's-text-subtle',
-  active: 's-text-link',
-  icon: 'mx-auto',
-  content: 'flex items-center justify-center gap-8',
-  contentUnderlined: 'content-underlined', // content-underlined is a no-op that prevents a quirk in how Vue handles class bindings
-};
-
-// Todo: Handle dynamic classnames
-export const gridLayout = {
-  cols1: 'grid-cols-1',
-  cols2: 'grid-cols-2',
-  cols3: 'grid-cols-3',
-  cols4: 'grid-cols-4',
-  cols5: 'grid-cols-5',
-  cols6: 'grid-cols-6',
-  cols7: 'grid-cols-7',
-  cols8: 'grid-cols-8',
-  cols9: 'grid-cols-9',
-};
-
-export const buttonReset = 'focus:outline-none appearance-none cursor-pointer bg-transparent border-0 m-0 p-0 inline-block';
-
-export const expandable = {
-  wrapper: 'will-change-height s-text',
-  box: 's-surface-sunken hover:s-bg-hover active:s-bg-active py-0 px-0 group block relative break-words last-child:mb-0 rounded-8',
-  bleed: '-mx-16 rounded-l-0 rounded-r-0 sm:mx-0 sm:rounded-8',
-  chevron: 'inline-block align-middle s-icon',
-  chevronNonBox: 'ml-8',
-  chevronTransform: 'transform transition-transform transform-gpu ease-in-out',
-  chevronExpand: '-rotate-180',
-  chevronCollapse: 'rotate-180',
-
-  // These are web component specific classes, using the ::part-selector:
-  elementsChevronDownTransform:
-    'part-[w-icon-chevron-down-16-part]:transform part-[w-icon-chevron-down-16-part]:transition-transform part-[w-icon-chevron-down-16-part]:transform-gpu part-[w-icon-chevron-down-16-part]:ease-in-out',
-  elementsChevronUpTransform:
-    'part-[w-icon-chevron-up-16-part]:transform part-[w-icon-chevron-up-16-part]:transition-transform part-[w-icon-chevron-up-16-part]:transform-gpu part-[w-icon-chevron-up-16-part]:ease-in-out',
-  elementsChevronExpand: 'part-[w-icon-chevron-down-16-part]:-rotate-180',
-  elementsChevronCollapse: 'part-[w-icon-chevron-up-16-part]:rotate-180',
-
-  expansion: 'overflow-hidden',
-  expansionNotExpanded: 'h-0 invisible',
-  button: 'focus:outline-none appearance-none cursor-pointer bg-transparent border-0 m-0 hover:underline focus-visible:underline',
-  buttonBox: 'w-full text-left relative inline-flex items-center justify-between group relative break-words last-child:mb-0 p-16 rounded-8',
-  contentWithTitle: 'pt-0',
-  title: 'flex w-full justify-between items-center',
-  titleType: 't4',
-};
-
-const buttonDefaultStyling = 'font-bold focusable justify-center transition-colors ease-in-out';
-
 const buttonColors = {
   primary:
     's-text-inverted bg-[--w-color-button-primary-background] hover:bg-[--w-color-button-primary-background-hover] active:bg-[--w-color-button-primary-background-active]',
@@ -212,6 +12,8 @@ const buttonColors = {
   loading: 's-text s-bg-subtle',
   link: 's-text-link',
 };
+
+const buttonDefaultStyling = 'font-bold focusable justify-center transition-colors ease-in-out';
 
 const buttonTypes = {
   primary: `border-0 rounded-8 ${buttonDefaultStyling}`,
@@ -245,6 +47,90 @@ const buttonVariants = {
   utilityQuiet: `border-0 rounded-4 ${buttonDefaultStyling}`,
   negativeQuiet: `border-0 rounded-8 ${buttonDefaultStyling}`,
   isDisabled: `font-bold justify-center transition-colors ease-in-out cursor-default pointer-events-none ${buttonColors.disabled}`, // .button:disabled, .button--is-disabled
+};
+
+const prefixSuffixWrapper =
+  'absolute top-0 bottom-0 flex justify-center items-center focusable rounded-4 focus:[--w-outline-offset:-2px] bg-transparent ';
+
+  
+export const alert = {
+  wrapper: 'flex p-16 border border-l-4 rounded-4 s-text',
+  willChangeHeight: 'will-change-height',
+  textWrapper: 'last-child:mb-0 text-s',
+  title: 'text-s',
+  icon: 'w-16 mr-8 min-w-16',
+  negative: 's-border-negative-subtle s-border-l-negative s-bg-negative-subtle',
+  negativeIcon: 's-icon-negative',
+  positive: 's-border-positive-subtle s-border-l-positive s-bg-positive-subtle',
+  positiveIcon: 's-icon-positive',
+  warning: 's-border-warning-subtle s-border-l-warning s-bg-warning-subtle',
+  warningIcon: 's-icon-warning',
+  info: 's-border-info-subtle s-border-l-info s-bg-info-subtle',
+  infoIcon: 's-icon-info',
+};
+
+export const attention = {
+  base: 'border-2 relative flex items-start',
+  tooltip: 's-bg-inverted border-[--w-s-color-background-inverted] shadow-m s-text-inverted-static rounded-4 py-6 px-8',
+  callout: 'bg-[--w-color-callout-background] border-[--w-color-callout-border] s-text py-8 px-16 rounded-8',
+  highlight: 'bg-[--w-color-callout-background] border-[--w-color-callout-border] s-text py-8 px-16 rounded-8 drop-shadow-m translate-z-0',
+  popover:
+    'bg-[--w-s-color-surface-elevated-300] border-[--w-s-color-surface-elevated-300] s-text rounded-8 p-16 drop-shadow-m translate-z-0',
+
+  arrowBase: 'absolute h-[14px] w-[14px] border-2 border-b-0 border-r-0 rounded-tl-4 transform',
+  arrowDirectionLeftStart: '-left-[8px]',
+  arrowDirectionLeft: '-left-[8px]',
+  arrowDirectionLeftEnd: '-left-[8px]',
+  arrowDirectionRightStart: '-right-[8px]',
+  arrowDirectionRight: '-right-[8px]',
+  arrowDirectionRightEnd: '-right-[8px]',
+  arrowDirectionBottomStart: '-bottom-[8px]',
+  arrowDirectionBottom: '-bottom-[8px]',
+  arrowDirectionBottomEnd: '-bottom-[8px]',
+  arrowDirectionTopStart: '-top-[8px]',
+  arrowDirectionTop: '-top-[8px]',
+  arrowDirectionTopEnd: '-top-[8px]',
+  arrowTooltip: 's-bg-inverted border-[--w-s-color-background-inverted]',
+  arrowCallout: 'bg-[--w-color-callout-background] border-[--w-color-callout-border]',
+  arrowPopover: 'bg-[--w-s-color-surface-elevated-300] border-[--w-s-color-surface-elevated-300]',
+  arrowHighlight: 'bg-[--w-color-callout-background] border-[--w-color-callout-border]',
+
+  content: 'last-child:mb-0',
+  notCallout: 'absolute z-50',
+  closeBtn: `${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill} justify-self-end -mr-8 ml-8`,
+};
+
+export const badge = {
+  base: 'py-4 px-8 border-0 rounded-4 text-xs inline-flex',
+  neutral: 'bg-[--w-color-badge-neutral-background] s-text',
+  info: 'bg-[--w-color-badge-info-background] s-text',
+  positive: 'bg-[--w-color-badge-positive-background] s-text',
+  warning: 'bg-[--w-color-badge-warning-background] s-text',
+  negative: 'bg-[--w-color-badge-negative-background] s-text',
+  disabled: 's-bg-disabled s-text',
+  price: 'bg-[--w-black/70] s-text-inverted-static',
+  sponsored: 'bg-[--w-color-badge-sponsored-background] s-text',
+  positionBase: 'absolute backdrop-blur',
+  positionTL: 'rounded-tl-0 rounded-tr-0 rounded-bl-0 top-0 left-0',
+  positionTR: 'rounded-tl-0 rounded-tr-0 rounded-br-0 top-0 right-0',
+  positionBR: 'rounded-tr-0 rounded-br-0 rounded-bl-0 bottom-0 right-0',
+  positionBL: 'rounded-tl-0 rounded-br-0 rounded-bl-0 bottom-0 left-0',
+};
+
+export const box = {
+  base: 'group block relative break-words last-child:mb-0 p-16 rounded-8', // Relative here enables w-clickable
+  bleed: '-mx-16 sm:mx-0 rounded-l-0 rounded-r-0 sm:rounded-8', // We target L and R to override the default rounded-8
+  info: 's-bg-info-subtle',
+  neutral: 's-surface-sunken',
+  bordered: 'border-2 s-border s-bg',
+};
+
+export const breadcrumbs = {
+  wrapper: 'flex space-x-8',
+  text: 's-text',
+  link: 's-text-link',
+  separator: 'select-none s-icon',
+  a11y: 'sr-only',
 };
 
 export const button = {
@@ -337,6 +223,107 @@ export const buttonGroupItem = {
   selected: 'z-30 bg-[--w-color-buttongroup-utility-background-selected]',
 };
 
+export const buttonReset = 'focus:outline-none appearance-none cursor-pointer bg-transparent border-0 m-0 p-0 inline-block';
+
+export const card = {
+  base: 'cursor-pointer overflow-hidden relative transition-all',
+  shadow: 'group rounded-8 s-surface-elevated-200 hover:s-surface-elevated-200-hover active:s-surface-elevated-200-active',
+  selected: '!s-bg-selected !hover:s-bg-selected-hover !active:s-bg-selected-active',
+  outline: 'absolute border-2 rounded-8 inset-0 transition-all',
+  outlineUnselected: 'border-transparent group-active:s-border-active',
+  outlineSelected: 's-border-selected group-hover:s-border-selected-hover group-active:s-border-selected-active',
+  flat: 'border-2 rounded-4',
+  flatUnselected: 's-bg hover:s-bg-hover active:s-bg-active s-border hover:s-border-hover active:s-border-active',
+  flatSelected:
+    's-bg-selected hover:s-bg-selected-hover active:s-bg-selected-active s-border-selected hover:s-border-selected-hover active:s-border-selected-active',
+  a11y: 'sr-only',
+};
+
+export const clickable = {
+  toggle: 'absolute inset-0 h-full w-full appearance-none cursor-pointer focusable focusable-inset',
+  label: 'antialiased block relative text-s font-bold s-text px-12 py-8 cursor-pointer focusable focusable-inset',
+  buttonOrLink: 'bg-transparent focusable',
+  buttonOrLinkStretch: 'inset-0 absolute',
+};
+
+export const combobox = {
+  wrapper: 'relative',
+  base: 'absolute left-0 right-0 pb-8 rounded-8 shadow-m',
+  listbox: 'm-0 p-0 select-none list-none',
+  option: 'block cursor-pointer p-8',
+  optionUnselected: 's-bg hover:s-bg-hover',
+  optionSelected: 's-bg-selected hover:s-bg-selected-hover',
+  textMatch: 'font-bold',
+  a11y: 'sr-only',
+};
+
+export const expandable = {
+  wrapper: 'will-change-height s-text',
+  box: 's-surface-sunken hover:s-bg-hover active:s-bg-active py-0 px-0 group block relative break-words last-child:mb-0 rounded-8',
+  bleed: '-mx-16 rounded-l-0 rounded-r-0 sm:mx-0 sm:rounded-8',
+  chevron: 'inline-block align-middle s-icon',
+  chevronNonBox: 'ml-8',
+  chevronTransform: 'transform transition-transform transform-gpu ease-in-out',
+  chevronExpand: '-rotate-180',
+  chevronCollapse: 'rotate-180',
+
+  // These are web component specific classes, using the ::part-selector:
+  elementsChevronDownTransform:
+    'part-[w-icon-chevron-down-16-part]:transform part-[w-icon-chevron-down-16-part]:transition-transform part-[w-icon-chevron-down-16-part]:transform-gpu part-[w-icon-chevron-down-16-part]:ease-in-out',
+  elementsChevronUpTransform:
+    'part-[w-icon-chevron-up-16-part]:transform part-[w-icon-chevron-up-16-part]:transition-transform part-[w-icon-chevron-up-16-part]:transform-gpu part-[w-icon-chevron-up-16-part]:ease-in-out',
+  elementsChevronExpand: 'part-[w-icon-chevron-down-16-part]:-rotate-180',
+  elementsChevronCollapse: 'part-[w-icon-chevron-up-16-part]:rotate-180',
+
+  expansion: 'overflow-hidden',
+  expansionNotExpanded: 'h-0 invisible',
+  button: 'focus:outline-none appearance-none cursor-pointer bg-transparent border-0 m-0 hover:underline focus-visible:underline',
+  buttonBox: 'w-full text-left relative inline-flex items-center justify-between group relative break-words last-child:mb-0 p-16 rounded-8',
+  contentWithTitle: 'pt-0',
+  title: 'flex w-full justify-between items-center',
+  titleType: 't4',
+};
+
+// Todo: Handle dynamic classnames
+export const gridLayout = {
+  cols1: 'grid-cols-1',
+  cols2: 'grid-cols-2',
+  cols3: 'grid-cols-3',
+  cols4: 'grid-cols-4',
+  cols5: 'grid-cols-5',
+  cols6: 'grid-cols-6',
+  cols7: 'grid-cols-7',
+  cols8: 'grid-cols-8',
+  cols9: 'grid-cols-9',
+};
+
+export const helpText = {
+  base: 'text-xs mt-4 block',
+  color: 's-text-subtle',
+  colorInvalid: 's-text-negative',
+};
+
+export const input = {
+  // wrapper classes
+  wrapper: 'relative',
+  // input classes
+  base: 'block text-m leading-m mb-0 px-8 py-12 rounded-4 w-full focusable focus:[--w-outline-offset:-2px] caret-current', // true
+  default: 'border-1 s-text s-bg s-border hover:s-border-hover active:s-border-selected', // !isInvalid && !isDisabled && !isReadOnly
+  disabled: 'border-1 s-text-disabled s-bg-disabled-subtle s-border-disabled pointer-events-none', // !isInvalid && isDisabled && !isReadOnly
+  invalid: 'border-1 s-text-negative s-bg s-border-negative hover:s-border-negative-hover outline-[--w-s-color-border-negative]!', // isInvalid && !isDisabled && !isReadOnly
+  readOnly: 'pl-0 bg-transparent pointer-events-none', // !isInvalid && !isDisabled && isReadOnly
+  placeholder: 'placeholder:s-text-placeholder',
+  suffix: 'pr-40',
+  prefix: 'pl-[var(--w-prefix-width,_40px)]',
+  // textarea classes
+  textArea: 'min-h-[42] sm:min-h-[45]',
+};
+
+export const label = {
+  base: 'antialiased block relative text-s font-bold pb-4 cursor-pointer s-text',
+  optional: 'pl-8 font-normal text-s s-text-subtle',
+};
+
 export const modal = {
   backdrop:
     'fixed inset-0 flex sm:place-content-center sm:place-items-center items-end z-30 [--w-modal-max-height:80%] [--w-modal-width:640px] bg-[--w-black/25]',
@@ -379,36 +366,42 @@ export const modalElement = {
   footer: 'flex justify-end shrink-0 px-16 sm:px-32 pt-24',
 };
 
-export const alert = {
-  wrapper: 'flex p-16 border border-l-4 rounded-4 s-text',
-  willChangeHeight: 'will-change-height',
-  textWrapper: 'last-child:mb-0 text-s',
-  title: 'text-s',
-  icon: 'w-16 mr-8 min-w-16',
-  negative: 's-border-negative-subtle s-border-l-negative s-bg-negative-subtle',
-  negativeIcon: 's-icon-negative',
-  positive: 's-border-positive-subtle s-border-l-positive s-bg-positive-subtle',
-  positiveIcon: 's-icon-positive',
-  warning: 's-border-warning-subtle s-border-l-warning s-bg-warning-subtle',
-  warningIcon: 's-icon-warning',
-  info: 's-border-info-subtle s-border-l-info s-bg-info-subtle',
-  infoIcon: 's-icon-info',
+export const pageIndicator = {
+  wrapper: 'flex space-x-8 p-8',
+  dot: 'h-8 w-8 rounded-full',
+  inactive: 's-bg-disabled-subtle hover:bg-[--w-s-icon-subtle]',
+  active: 'bg-[--w-s-icon-selected]',
 };
 
-export const input = {
-  // wrapper classes
-  wrapper: 'relative',
-  // input classes
-  base: 'block text-m leading-m mb-0 px-8 py-12 rounded-4 w-full focusable focus:[--w-outline-offset:-2px] caret-current', // true
-  default: 'border-1 s-text s-bg s-border hover:s-border-hover active:s-border-selected', // !isInvalid && !isDisabled && !isReadOnly
-  disabled: 'border-1 s-text-disabled s-bg-disabled-subtle s-border-disabled pointer-events-none', // !isInvalid && isDisabled && !isReadOnly
-  invalid: 'border-1 s-text-negative s-bg s-border-negative hover:s-border-negative-hover outline-[--w-s-color-border-negative]!', // isInvalid && !isDisabled && !isReadOnly
-  readOnly: 'pl-0 bg-transparent pointer-events-none', // !isInvalid && !isDisabled && isReadOnly
-  placeholder: 'placeholder:s-text-placeholder',
-  suffix: 'pr-40',
-  prefix: 'pl-[var(--w-prefix-width,_40px)]',
-  // textarea classes
-  textArea: 'min-h-[42] sm:min-h-[45]',
+export const pagination = {
+  link: 'hover:no-underline focus:no-underline focusable inline-flex justify-center items-center transition-colors ease-in-out min-h-[44px] min-w-[44px] p-4 rounded-full border-0 hover:bg-clip-padding',
+  currentPage: 'block md:hidden p-8 font-bold',
+  icon: 's-icon hover:bg-[--w-color-button-pill-background-hover] active:bg-[--w-color-button-pill-background-active]',
+  containerNav: 'flex items-center justify-center p-8',
+  a11y: 'sr-only',
+  pages: 'hidden md:block s-text-link',
+  active: 's-bg-primary s-text-inverted',
+  notActive: 'hover:bg-[--w-color-button-pill-background-hover] active:bg-[--w-color-button-pill-background-active]',
+};
+
+export const pill = {
+  wrapper: 'flex items-center',
+  button: 'inline-flex items-center focusable text-xs transition-all',
+  suggestion:
+    'bg-[--w-color-pill-suggestion-background] hover:bg-[--w-color-pill-suggestion-background-hover] active:bg-[--w-color-pill-suggestion-background-active] s-text font-bold',
+  filter: 's-bg-primary hover:s-bg-primary-hover active:s-bg-primary-active s-text-inverted',
+  label: 'pl-12 py-8 rounded-l-full',
+  labelWithoutClose: 'pr-12 rounded-r-full',
+  labelWithClose: 'pr-2',
+  close: 'pr-12 pl-4 py-8 rounded-r-full',
+  a11y: 'sr-only',
+};
+
+export const prefix = {
+  wrapper: prefixSuffixWrapper + 'left-0',
+  wrapperWithLabel: 'w-max pl-12',
+  wrapperWithIcon: 'w-40',
+  label: 'antialiased block relative cursor-default pb-0 font-bold text-xs s-text',
 };
 
 export const select = {
@@ -425,19 +418,52 @@ export const select = {
   chevronDisabled: 'opacity-25',
 };
 
-export const label = {
-  base: 'antialiased block relative text-s font-bold pb-4 cursor-pointer s-text',
-  optional: 'pl-8 font-normal text-s s-text-subtle',
+export const slider = {
+  wrapper: 'touch-pan-y relative w-full h-44 py-2',
+  track: 'absolute s-bg-disabled-subtle h-4 top-20 rounded-4 w-full',
+  trackDisabled: 'pointer-events-none',
+  activeTrack: 'absolute h-6 top-[19px] rounded-4',
+  activeTrackEnabled: 's-bg-primary',
+  activeTrackDisabled: 's-bg-disabled pointer-events-none',
+  thumb: 'absolute transition-shadow w-24 h-24 bottom-10 rounded-4 outline-none',
+  thumbEnabled:
+    'border-2 shadow-[--w-shadow-slider] cursor-pointer s-bg-primary s-border-primary hover:s-bg-primary-hover hover:s-border-primary-hover hover:shadow-[--w-shadow-slider-handle-hover] active:s-bg-primary-active active:s-border-primary-active active:shadow-[--w-shadow-slider-handle-active] focus:shadow-[--w-shadow-slider-handle-hover] focus:s-border-primary-hover focus:s-bg-primary-hover',
+  thumbDisabled: 's-bg-disabled cursor-disabled pointer-events-none',
 };
 
-export const helpText = {
-  base: 'text-xs mt-4 block',
-  color: 's-text-subtle',
-  colorInvalid: 's-text-negative',
+export const step = {
+  container: 'group/step',
+  vertical: 'group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16',
+  horizontal: 'group/steph grid-rows-[auto_20px] grid-cols-[1fr_20px_1fr] flex-1 grid gap-y-16 items-center',
+
+  alignLeft: 'grid-cols-[20px_1fr]',
+  alignRight: 'grid-cols-[1fr_20px] text-right',
+
+  dot: 'rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted',
+  dotAlignRight: 'col-start-2',
+  dotHorizontal: 'row-start-2 justify-self-end',
+  dotActive: 's-border-primary s-bg-primary',
+  dotIncomplete: 's-border s-bg',
+
+  line: 'group-last/stepv:hidden transition-colors duration-300',
+  lineVertical: 'w-2 h-full justify-self-center',
+  lineAlignRight: 'col-start-2',
+  lineHorizontal: 'h-2 w-full row-start-2',
+  lineHorizontalAlignRight: 'group-last/steph:bg-transparent',
+  lineHorizontalAlignLeft: 'group-first/steph:bg-transparent',
+
+  lineIncomplete: 's-bg-disabled',
+  lineComplete: 's-bg-primary',
+
+  content: 'last:mb-0 group-last/step:last:pb-0',
+  contentVertical: 'row-span-2 pb-32',
+  contentHorizontal: 'col-span-3 px-16 row-start-1 text-center',
 };
 
-const prefixSuffixWrapper =
-  'absolute top-0 bottom-0 flex justify-center items-center focusable rounded-4 focus:[--w-outline-offset:-2px] bg-transparent ';
+export const steps = {
+  container: 'w-full',
+  horizontal: 'flex',
+};
 
 export const suffix = {
   wrapper: prefixSuffixWrapper + 'right-0',
@@ -446,18 +472,55 @@ export const suffix = {
   label: 'antialiased block relative cursor-default pb-0 font-bold text-xs s-text',
 };
 
-export const prefix = {
-  wrapper: prefixSuffixWrapper + 'left-0',
-  wrapperWithLabel: 'w-max pl-12',
-  wrapperWithIcon: 'w-40',
-  label: 'antialiased block relative cursor-default pb-0 font-bold text-xs s-text',
+export const tab = {
+  base: 'grid items-center font-bold gap-8 focusable antialias p-16 pb-8 border-b-4 bg-transparent border-transparent hover:s-text-link hover:s-border-primary',
+  inactive: 's-text-subtle',
+  active: 's-text-link',
+  icon: 'mx-auto',
+  content: 'flex items-center justify-center gap-8',
+  contentUnderlined: 'content-underlined', // content-underlined is a no-op that prevents a quirk in how Vue handles class bindings
 };
 
-export const breadcrumbs = {
-  wrapper: 'flex space-x-8',
-  text: 's-text',
-  link: 's-text-link',
-  separator: 'select-none s-icon',
+export const tabs = {
+  wrapper: 'inline-block border-b s-border mb-32',
+  container: 'inline-grid relative -mb-1',
+  selectionIndicator: 'absolute s-border-selected -bottom-0 border-b-4 transition-all',
+};
+
+export const toast = {
+  wrapper: 'relative overflow-hidden w-full',
+  base: 'flex group p-8 mt-16 rounded-8 border-2 pointer-events-auto transition-all',
+  positive: 's-bg-positive-subtle s-border-positive-subtle s-text',
+  warning: 's-bg-warning-subtle s-border-warning-subtle s-text',
+  negative: 's-bg-negative-subtle s-border-negative-subtle s-text',
+  iconBase: 'shrink-0 rounded-full w-[16px] h-[16px] m-[8px]',
+  iconPositive: 's-icon-positive',
+  iconWarning: 's-icon-warning',
+  iconNegative: 's-icon-negative',
+  iconLoading: 'animate-bounce',
+  content: 'self-center mr-8 py-4 last-child:mb-0',
+  close: 'bg-transparent ml-auto p-[8px] s-icon hover:s-icon-hover active:s-icon-active',
+};
+
+export const toaster = {
+  container: 'fixed transform translate-z-0 bottom-16 left-0 right-0 mx-8 sm:mx-16 z-50 pointer-events-none',
+  base: 'grid auto-rows-auto justify-items-center justify-center mx-auto pointer-events-none',
+  content: 'w-full',
+};
+
+
+// TOGGLE COMPONENTS:
+export const switchToggle = {
+  label: 'block relative h-24 w-44 cursor-pointer group',
+  labelDisabled: 'pointer-events-none',
+  track: 'absolute top-0 left-0 h-full w-full rounded-full transition-colors',
+  trackActive: 's-bg-primary group-hover:s-bg-primary-hover',
+  trackInactive: 'bg-[--w-color-switch-track-background] group-hover:bg-[--w-color-switch-track-background-hover]',
+  trackDisabled: 's-bg-disabled-subtle',
+  handle: 'absolute transform-gpu h-16 w-16 top-4 left-4 rounded-full transition-transform',
+  handleSelected: 'translate-x-20',
+  handleNotDisabled: 's-bg shadow-s',
+  handleDisabled: 's-bg-disabled',
   a11y: 'sr-only',
 };
 
@@ -508,67 +571,7 @@ export const deadToggle = {
   wrapper: `${toggle.wrapper} h-20 w-20 pointer-events-none`,
   input: `${toggle.input} hidden`,
   inputVue: 'hidden',
+  labelVue: '-mt-2',
   labelRadio: `${toggle.label} ${toggle.labelBefore} ${toggle.radio}`,
   labelCheckbox: `${toggle.label} ${toggle.labelBefore} ${toggle.checkbox}`,
-  labelVue: '-mt-2',
-};
-
-export const clickable = {
-  toggle: 'absolute inset-0 h-full w-full appearance-none cursor-pointer focusable focusable-inset',
-  label: `px-12 ${label.base} py-8! cursor-pointer focusable focusable-inset`,
-  buttonOrLink: 'bg-transparent focusable',
-  buttonOrLinkStretch: 'inset-0 absolute',
-};
-
-export const combobox = {
-  wrapper: 'relative',
-  base: 'absolute left-0 right-0 pb-8 rounded-8 shadow-m',
-  listbox: 'm-0 p-0 select-none list-none',
-  option: 'block cursor-pointer p-8',
-  optionUnselected: 's-bg hover:s-bg-hover',
-  optionSelected: 's-bg-selected hover:s-bg-selected-hover',
-  textMatch: 'font-bold',
-  a11y: 'sr-only',
-};
-
-export const attention = {
-  base: 'border-2 relative flex items-start',
-  tooltip: 's-bg-inverted border-[--w-s-color-background-inverted] shadow-m s-text-inverted-static rounded-4 py-6 px-8',
-  callout: 'bg-[--w-color-callout-background] border-[--w-color-callout-border] s-text py-8 px-16 rounded-8',
-  highlight: 'bg-[--w-color-callout-background] border-[--w-color-callout-border] s-text py-8 px-16 rounded-8 drop-shadow-m translate-z-0',
-  popover:
-    'bg-[--w-s-color-surface-elevated-300] border-[--w-s-color-surface-elevated-300] s-text rounded-8 p-16 drop-shadow-m translate-z-0',
-
-  arrowBase: 'absolute h-[14px] w-[14px] border-2 border-b-0 border-r-0 rounded-tl-4 transform',
-  arrowDirectionLeftStart: '-left-[8px]',
-  arrowDirectionLeft: '-left-[8px]',
-  arrowDirectionLeftEnd: '-left-[8px]',
-  arrowDirectionRightStart: '-right-[8px]',
-  arrowDirectionRight: '-right-[8px]',
-  arrowDirectionRightEnd: '-right-[8px]',
-  arrowDirectionBottomStart: '-bottom-[8px]',
-  arrowDirectionBottom: '-bottom-[8px]',
-  arrowDirectionBottomEnd: '-bottom-[8px]',
-  arrowDirectionTopStart: '-top-[8px]',
-  arrowDirectionTop: '-top-[8px]',
-  arrowDirectionTopEnd: '-top-[8px]',
-  arrowTooltip: 's-bg-inverted border-[--w-s-color-background-inverted]',
-  arrowCallout: 'bg-[--w-color-callout-background] border-[--w-color-callout-border]',
-  arrowPopover: 'bg-[--w-s-color-surface-elevated-300] border-[--w-s-color-surface-elevated-300]',
-  arrowHighlight: 'bg-[--w-color-callout-background] border-[--w-color-callout-border]',
-
-  content: 'last-child:mb-0',
-  notCallout: 'absolute z-50',
-  closeBtn: `${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill} justify-self-end -mr-8 ml-8`,
-};
-
-export const pagination = {
-  link: 'hover:no-underline focus:no-underline focusable inline-flex justify-center items-center transition-colors ease-in-out min-h-[44px] min-w-[44px] p-4 rounded-full border-0 hover:bg-clip-padding',
-  currentPage: 'block md:hidden p-8 font-bold',
-  icon: 's-icon hover:bg-[--w-color-button-pill-background-hover] active:bg-[--w-color-button-pill-background-active]',
-  containerNav: 'flex items-center justify-center p-8',
-  a11y: 'sr-only',
-  pages: 'hidden md:block s-text-link',
-  active: 's-bg-primary s-text-inverted',
-  notActive: 'hover:bg-[--w-color-button-pill-background-hover] active:bg-[--w-color-button-pill-background-active]',
 };


### PR DESCRIPTION
**Changes:**
1. Restructured component-classes/index.js file:
- Moved all variables to the top of the page
- Sorted all exported objects alphabetically (except for toggle components: `deadToggle` object cannot be sorted alphabetically due to that it uses styling from the `toggle` component that would be declared after `deadToggle`)

2. Renamed classnames for better readability and consistency:
- prefixSuffixWrapperBase —> prefixSuffixWrapper
- box.box —> box.base
- pill.pill —> pill.wrapper
- toaster.toaster —> toaster.base
- tabs.tabContainer —> tabs.container
- tabs.wunderbar —> tabs.selectionIndicator
- tabs.wrapperUnderlined —> tabs.wrapper
- tab.tab —> tab.base
- tab.tabInactive —> tab.inactive
- tab.tabActive —> tab.active
- expandable —> wrapper
- expandable.expandableBox —> expandable.box
- expandable.expandableBleed —> expandable.bleed
- modal.modal —> modal.base
- alert.alert —> alert.wrapper
- label.label —> label.base
- helpText.helpText —> helpText.base
- helpText.helpTextColor —> helpText.color
- helpText.helpTextColorInvalid —> helpText.colorInvalid
