### PR TITLE
fix(clickable): clean up classes

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -517,7 +517,7 @@ export const deadToggle = {
 
 export const clickable = {
   toggle: 'absolute inset-0 h-full w-full appearance-none cursor-pointer focusable focusable-inset',
-  label: `px-12 ${label.label} py-8! cursor-pointer focusable focusable-inset`,
+  label: 'antialiased block relative text-s font-bold s-text px-12 py-8 cursor-pointer focusable focusable-inset',
   buttonOrLink: 'bg-transparent focusable',
   buttonOrLinkStretch: 'inset-0 absolute',
 };


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the `Clickable` component.

**Changes:**
- Refactor clickable.label to not have important to override padding-bottom

## Testing
Tested the changes in @warp-ds/vue (ccClickable.label is only used in vue)