### PR TITLE
fix(tokens): update to correct color in button-pill-background-hover

### DIFF
--- a/tokens/blocket.se/buttons.yml
+++ b/tokens/blocket.se/buttons.yml
@@ -6,4 +6,4 @@ color:
     pill:
       background:
         active: blue-400/30
-        hover: blue-400/40
+        hover: blue-300/30

--- a/tokens/dba.dk/buttons.yml
+++ b/tokens/dba.dk/buttons.yml
@@ -6,4 +6,4 @@ color:
     pill:
       background:
         active: jeanblue-400/30
-        hover: jeanblue-400/40        
+        hover: jeanblue-300/30

--- a/tokens/finn.no/buttons.yml
+++ b/tokens/finn.no/buttons.yml
@@ -6,4 +6,4 @@ color:
     pill:
       background:
         active: blue-400/30
-        hover: blue-400/40
+        hover: blue-300/30

--- a/tokens/tori.fi/buttons.yml
+++ b/tokens/tori.fi/buttons.yml
@@ -6,4 +6,4 @@ color:
     pill:
       background:
         active: blueberry-400/30
-        hover: blueberry-400/40
+        hover: blueberry-300/30


### PR DESCRIPTION
Fixes [WARP-567](https://nmp-jira.atlassian.net/browse/WARP-567)

The background color of a hovered button of type "pill" is now lighter than the active one.

![Fixed button pill background hover color](https://github.com/user-attachments/assets/bef79b0d-b1fa-48bf-93c4-43fa2f107ffe)
![Fixed Modal button color on hover and active](https://github.com/user-attachments/assets/f1477771-b100-462c-a26e-3e32e2225e02)

