### PR TITLE
fix(switchtoggle): clean up classes

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -463,9 +463,10 @@ export namespace toaster {
     export { content_5 as content };
 }
 export namespace switchToggle {
-    let label_4: string;
-    export { label_4 as label };
-    export let labelDisabled: string;
+    let base_13: string;
+    export { base_13 as base };
+    let disabled_3: string;
+    export { disabled_3 as disabled };
     let track_1: string;
     export { track_1 as track };
     export let trackActive: string;
@@ -490,8 +491,8 @@ export namespace toggle {
     export let input: string;
     let a11y_7: string;
     export { a11y_7 as a11y };
-    let label_5: string;
-    export { label_5 as label };
+    let label_4: string;
+    export { label_4 as label };
     export let labelBefore: string;
     export let checkbox: string;
     export let checkboxInvalid: string;

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -509,8 +509,8 @@ export const toaster = {
 
 // TOGGLE COMPONENTS:
 export const switchToggle = {
-  label: 'block relative h-24 w-44 cursor-pointer group',
-  labelDisabled: 'pointer-events-none',
+  base: 'block relative h-24 w-44 cursor-pointer group focusable rounded-full',
+  disabled: 'pointer-events-none',
   track: 'absolute top-0 left-0 h-full w-full rounded-full transition-colors',
   trackActive: 's-bg-primary group-hover:s-bg-primary-hover',
   trackInactive: 'bg-[--w-color-switch-track-background] group-hover:bg-[--w-color-switch-track-background-hover]',


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the `switchToggle` component.

**Changes:**
- Rename `switchToggle.label` to `switchToggle.base`
- Rename `switchToggle.labelDisabled` to `switchToggle.disabled`
- Add `focusable rounded-full` to `switchToggle.base` that was previously hardcoded in the React `Switch` component

## Testing
Tested the changes in @warp-ds/react (fix/cleanup-switch-toggle-classes) and @warp-ds/vue (fix/update-classnames)