### PR TITLE
fix: Background color fixes for Combobox component

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -522,10 +522,10 @@ export const clickable = {
 
 export const combobox = {
   wrapper: 'relative',
-  base: 'absolute left-0 right-0 pb-8 rounded-8 shadow-m',
+  base: 'absolute left-0 right-0 s-bg pb-4 rounded-8 overflow-hidden shadow-m',
   listbox: 'm-0 p-0 select-none list-none',
   option: 'block cursor-pointer p-8',
-  optionUnselected: 's-bg hover:s-bg-hover',
+  optionUnselected: 'hover:s-bg-hover',
   optionSelected: 's-bg-selected hover:s-bg-selected-hover',
   textMatch: 'font-bold',
   a11y: 'sr-only',


### PR DESCRIPTION
Prevent bleeding of background colors in rounded corners and fixes transparent bottom padding issue in Combobox component.

![image](https://github.com/user-attachments/assets/68cb3a5b-a814-439a-9a4a-80ad6945d199)

Reported here:
https://sch-chat.slack.com/archives/C04P0GYTHPV/p1724745202595269

![image](https://github.com/user-attachments/assets/29465d55-fec8-4b3b-8828-9aa84ac57a79)
