### PR TITLE
fix: disable svg tooltip on all sites

### DIFF
--- a/resets/resets.js
+++ b/resets/resets.js
@@ -450,4 +450,9 @@ body:not(:-moz-handler-blocked) fieldset {
   display: table-cell;
 }
 
+/* Disable pointer events on all SVGs */
+svg {
+  pointer-events: none;
+}
+
   `;


### PR DESCRIPTION
Disable tooltips on all SVGs on site because of the discussion we had with the a11y team.

This decision is based on our meeting with A11y team, notes here: https://github.com/warp-ds/notes/blob/main/Svg%20titles%2C%20A11y%20%26%20Best%20Practices.md