### PR TITLE
fix(tabs): set border on selected tab to fix SSR

### DIFF
--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -148,7 +148,7 @@ export const tabs = {
 export const tab = {
   base: 'grid items-center font-bold gap-8 focusable antialias p-16 pb-8 border-b-4 bg-transparent border-transparent hover:s-text-link hover:s-border-primary',
   inactive: 's-text-subtle',
-  active: 's-text-link',
+  active: 's-text-link s-border-selected',
   icon: 'mx-auto',
   content: 'flex items-center justify-center gap-8',
   contentUnderlined: 'content-underlined', // content-underlined is a no-op that prevents a quirk in how Vue handles class bindings


### PR DESCRIPTION
## Description
Fixes [WARP-638](https://nmp-jira.atlassian.net/browse/WARP-638)

Tab's selected border has so far been styled by a "selection-indicator" `span` of the Tabs component. That span's width and position was calculated based on `getBoundingClientRect()` of the child Tab, and after an animation was finished, the correct Tab got its bottom border. That way of indicating the selected tab does not work server-side, which led us to the solution suggested in this PR. By setting the bottom border color of the selected Tab to `s-border-selected` whenever it's active, we ensure it's styled correctly regardless of whether JavaScript is enabled or not. The animation of the span will remain, as this change does not interfere with that.

### Before - SSR without hydration (JS disabled):
<img width="313" alt="Screenshot of SSR Tabs without bottom border on the selected Tab" src="https://github.com/user-attachments/assets/934d22ff-e38c-49d5-ab48-b1d9b154126a">

### After - SSR without hydration (JS disabled):
<img width="308" alt="Screenshot of SSR Tabs with bottom border on the selected Tab" src="https://github.com/user-attachments/assets/4151e185-fd60-44ef-b783-f85d64c21bfe">

## Side effect
As a consequence of the suggested change, the selected tab style doesn't wait for the span animation to finish. Previously, when quickly removing the cursor from the activated tab, you could see that the selection indicator had to finish its animation before we could see the selected tab style:
![GIF displaying how Tabs border was not set until an animation was finished](https://github.com/user-attachments/assets/81f94d99-190a-4c42-8c44-ae51bd39590d)
With the suggested change, it looks like so:
![GIF displaying fixed Tabs border](https://github.com/user-attachments/assets/dfba7868-1b5e-490a-8e90-247ac370df13)

