### PR TITLE
feat: handle dataviz tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import tokenize from '@warp-ds/tokenizer';
+import fs from 'fs-extra';
 
 import { init, brandToName, downloadReleaseFile, generateFinalCss, getBrandModes, processHexCss, processRGBCss } from './utils.js';
 
@@ -15,9 +16,15 @@ brandModes.forEach((brandMode) => {
   console.log(`Processing ${brandMode}...`);
   const cssHex = processHexCss(brandMode);
   const cssRgb = processRGBCss(brandMode);
-  const cssTokens = tokenize(`./tokens/${brandToName(brandMode).replace('-', '.')}`);
+  let cssCustomTokens = '';
 
-  const css = cssHex + cssRgb + cssTokens;
+  const customTokensFilePath = `./tokens/${brandToName(brandMode).replace('-', '.')}`;
+
+  if (fs.existsSync(customTokensFilePath)) {
+    cssCustomTokens = tokenize(customTokensFilePath);
+  }
+
+  const css = cssHex + cssRgb + cssCustomTokens;
 
   console.log(`Outputting ${brandMode}...`);
   generateFinalCss(css, brandMode);

--- a/utils.js
+++ b/utils.js
@@ -43,14 +43,18 @@ export const brandToName = (brand) => {
       return 'tori-fi';
     case 'oikotie-light':
       return 'oikotie-fi';
+    case 'dataviz-light':
+      return 'dataviz';
   }
 };
 
 export const processHexCss = (brandMode) => {
+  const isDataVizToken = brandMode.includes('dataviz');
+
   let cssHex = fs.readFileSync(`./${outputDir}/${brandMode}/variables.css`, 'utf8');
   cssHex = cssHex.replaceAll(':root ', ':root,:host ');
-  cssHex = cssHex.replaceAll('--color-', '--w-');
-  cssHex = cssHex.replaceAll('--semantic-color-', '--w-s-color-');
+  cssHex = cssHex.replaceAll('--color-', isDataVizToken ? '--w-dv-' : '--w-');
+  cssHex = cssHex.replaceAll('--semantic-color-', isDataVizToken ? '--w-dv-s-color-' : '--w-s-color-');
   cssHex = cssHex.replaceAll('--components-', '--w-color-');
   cssHex = cssHex.replaceAll('-default:', ':');
 
@@ -63,10 +67,12 @@ export const processRGBCss = (brandMode) => {
   // this regex removes the components rgb values from the rgb css
   const componentsRGBRegex = /--components-.*?:\s*var\(\s*--.*\);/g;
 
+  const isDataVizToken = brandMode.includes('dataviz');
+
   let cssRgb = fs.readFileSync(`./${outputDir}/${brandMode}/variables-rgb.css`, 'utf8');
   cssRgb = cssRgb.replaceAll(':root ', ':root,:host ');
-  cssRgb = cssRgb.replaceAll('--color-', '--w-rgb-');
-  cssRgb = cssRgb.replaceAll('--semantic-color-', '--w-s-rgb-');
+  cssRgb = cssRgb.replaceAll('--color-', isDataVizToken ? '--w-dv-rgb-' : '--w-rgb-');
+  cssRgb = cssRgb.replaceAll('--semantic-color-', isDataVizToken ? '--w-dv-s-rgb-' : '--w-s-rgb-');
   cssRgb = cssRgb.replaceAll(componentsRGBRegex, '');
   cssRgb = cssRgb.replaceAll('-default:', ':');
   cssRgb = cssRgb.replaceAll(rgbValuesRegex, '$1');


### PR DESCRIPTION
Depends on https://github.com/warp-ds/tokens/pull/13

## Description
Fixes [WARP-643](https://nmp-jira.atlassian.net/browse/WARP-643)

This PR adds a `--w-dv-` prefix to all dataviz tokens fetched from the @warp-ds/tokens repo and publishes them as `dataviz.css` alongside other Warp brands CSS. 

Also adds a check whether there are any custom tokens files available under `./tokens` directory so the build script doesn't fail.