### PR TITLE
fix(dist): release renamed dataviz CSS variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const brandModes = getBrandModes();
 
 brandModes.forEach((brandMode) => {
   // skip dark themes and oikotie for now
-  if (brandMode.includes('dark') || brandMode.includes('oikotie')) return;
+  if (brandMode.includes('dark')) return;
 
   console.log(`Processing ${brandMode}...`);
   const cssHex = processHexCss(brandMode);


### PR DESCRIPTION
Dataline, datatext, datafill, databorder tokens lost the data- prefix. The change was updated in the warp-ds/tokens repo ([see here](https://github.com/warp-ds/tokens/pull/15/files#diff-8e597f6c38d7202a67059e0632eae085882ba015c2c33c7aa31d56765e4d1f59)), but requires a new release in this repo to be updated on Eik servers.

Additionally, I removed the check for oikotie brands from the build script as this brand is already filtered out in [warp-ds/tokens](https://github.com/warp-ds/tokens/blob/main/utils.js#L11).