### PR TITLE
fix: add removed class in a backward compatible list

### DIFF
--- a/component-classes/index.d.ts
+++ b/component-classes/index.d.ts
@@ -518,3 +518,6 @@ export namespace pagination {
     export { active_2 as active };
     export let notActive: string;
 }
+export namespace backwardsCompatibleClasses {
+    let removedActiveTrack: string;
+}

--- a/component-classes/index.js
+++ b/component-classes/index.js
@@ -572,3 +572,8 @@ export const pagination = {
   active: 's-bg-primary s-text-inverted',
   notActive: 'hover:bg-[--w-color-button-pill-background-hover] active:bg-[--w-color-button-pill-background-active]',
 };
+
+// remove these in v3
+export const backwardsCompatibleClasses = {
+  removedActiveTrack: 'top-[19px]',
+};


### PR DESCRIPTION
Adding any classes we remove in v2 into a `backwardsCompatibleClasses` object.